### PR TITLE
Typo fix - Call GetCurrentFunction

### DIFF
--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -493,7 +493,7 @@ export default class DanceParty {
     if (unit === "measures") {
       return this.getCurrentMeasure();
     } else {
-      return this.getCurrentTime;
+      return this.getCurrentTime();
     }
   }
 


### PR DESCRIPTION
Adding dropped parentheses.