### PR TITLE
move to newer p5.play that allows us to loadSpriteSheet as image element

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code-dot-org/dance-party",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "",
   "main": "dist/main.js",
   "scripts": {
@@ -16,7 +16,7 @@
   "author": "",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@code-dot-org/p5.play": "1.3.3-cdo",
+    "@code-dot-org/p5.play": "1.3.4-cdo",
     "eslint": "^2.8.0",
     "p5": "0.5.4",
     "webpack": "4.19.1",

--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -141,8 +141,12 @@ export default class DanceParty {
       this.world.MOVE_NAMES.forEach(({ name, mirror }, moveIndex) => {
         const baseUrl = `${img_base}${this_sprite}_${name}`;
         this.p5_.loadJSON(`${baseUrl}.json`, jsonData => {
+          // Passing true as the 3rd arg to loadSpriteSheet() indicates that we want
+          // it to load the image as a Image (instead of a p5.Image), which avoids
+          // a canvas creation. This makes it possible to run on mobile Safari in
+          // iOS 12 with canvas memory limits.
           ANIMATIONS[this_sprite][moveIndex] = {
-            spritesheet: this.p5_.loadSpriteSheet(`${baseUrl}.png`, jsonData.frames),
+            spritesheet: this.p5_.loadSpriteSheet(`${baseUrl}.png`, jsonData.frames, true),
             mirror,
           };
         });


### PR DESCRIPTION
* This allows us to use the work to avoid the canvas limitation issue that I recently added to p5.play: https://github.com/code-dot-org/p5.play/pull/44
