### PR TITLE
Fixes strobe flash character disappearing

### DIFF
--- a/src/Effects.js
+++ b/src/Effects.js
@@ -95,14 +95,13 @@ module.exports = class Effects {
           this.update();
         }
         if (this.flashing) {
-          bgcolor = p5.rgb(255, 255, 255);
           this.waitTime--;
+        } else {
+          p5.background(bgcolor);
         }
         if (this.waitTime <= 0) {
-          bgcolor = p5.rgb(1, 1, 1);
           this.flashing = false;
         }
-        p5.background(bgcolor);
       }
     };
 


### PR DESCRIPTION
Problem: Draws a black background over the dancers when it's 'dark' and draws a white background over the dancers when there is a 'flash'. White background covers the characters.

Solution: Only draw a background when it's 'dark'.