### PR TITLE
Load p5 helper

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,10 @@
-import p5 from 'p5';
-window.p5 = p5; // Needed for p5.play init.
-require('@code-dot-org/p5.play/lib/p5.play');
+import loadP5 from './loadP5';
 import DanceParty from './p5.dance';
 import macklemore90 from '../metadata/macklemore90.json';
 import hammer from '../metadata/hammer.json';
 import peas from '../metadata/peas.json';
 
-new window.p5(p5Inst => {
+loadP5().then(p5Inst => {
   const nativeAPI = window.nativeAPI = new DanceParty(p5Inst, {
     getSelectedSong: () => "hammer",
     onPuzzleComplete: () => {},

--- a/src/loadP5.js
+++ b/src/loadP5.js
@@ -1,0 +1,34 @@
+let context;
+
+if (typeof global !== undefined) {
+  context = global;
+
+  global.window = {
+    addEventListener: () => {
+    },
+  };
+
+  global.document = {
+    hasFocus: () => true,
+    getElementsByTagName: () => ({}),
+  };
+
+  global.screen = {};
+} else {
+  context = window;
+}
+
+const P5 = require('p5');
+
+context.define = function (_, _, callback) {
+  callback(P5);
+};
+context.define.amd = true;
+
+require('@code-dot-org/p5.play/lib/p5.play');
+
+module.exports = function () {
+  return new Promise(resolve => {
+    new P5(p5Inst => resolve(p5Inst));
+  });
+};

--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -35,7 +35,7 @@ module.exports = class DanceParty {
     /**
      * Patch p5 tint to use fast compositing (see https://github.com/code-dot-org/p5_play/pull/42).
      */
-    window.p5.Renderer2D.prototype._getTintedImageCanvas = function (img) {
+    Object.getPrototypeOf(p5).constructor.Renderer2D.prototype._getTintedImageCanvas = function (img) {
       this._tintCanvas = this._tintCanvas || document.createElement('canvas');
       this._tintCanvas.width = img.canvas.width;
       this._tintCanvas.height = img.canvas.height;
@@ -49,7 +49,7 @@ module.exports = class DanceParty {
       return this._tintCanvas;
     };
 
-    window.p5.disableFriendlyErrors = true;
+    Object.getPrototypeOf(p5).constructor.disableFriendlyErrors = true;
 
     this.currentFrameEvents = {
       'this.p5_.keyWentDown': {},

--- a/test/unit/sanity.js
+++ b/test/unit/sanity.js
@@ -1,23 +1,12 @@
 const test = require('tape');
+const loadP5 = require('../../src/loadP5');
 const DanceParty = require('../../src/p5.dance');
 
-global.window = {
-  addEventListener: () => {},
-};
-global.document = {
-  hasFocus: () => true,
-  getElementsByTagName: () => ({}),
-};
-global.screen = {};
-
-const p5 = require('p5');
-window.p5 = p5;
-
-p5.prototype.createGroup = () => {};
-
 test('sanity', t => {
-  const nativeAPI = new DanceParty(new p5(), () => {});
+  loadP5().then(p5Inst => {
+    const nativeAPI = new DanceParty(p5Inst, {});
 
-  t.notOk(nativeAPI.metadataLoaded());
-  t.end();
+    t.notOk(nativeAPI.metadataLoaded());
+    t.end();
+  });
 });


### PR DESCRIPTION
Addressing the cleanup we discussed (extracting the messiness of loading p5.play and creating a `p5Inst` into a separate helper).