### PR TITLE
remove metadataLoaded(), use p5.loadJSON to loadSongMetadata

### DIFF
--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -106,7 +106,6 @@ module.exports = class DanceParty {
     ];
 
     this.songStartTime_ = 0;
-    this.metadataLoaded_ = false;
   }
 
   pass() {
@@ -119,9 +118,7 @@ module.exports = class DanceParty {
 
   addCues(timestamps) {
     this.world.cues = timestamps;
-    if (this.metadataLoaded()) {
-      this.peaksData = METADATA[this.getSelectedSong_()].analysis.slice();
-    }
+    this.peaksData = METADATA[this.getSelectedSong_()].analysis.slice();
   }
 
   reset() {
@@ -135,14 +132,10 @@ module.exports = class DanceParty {
     this.world.bg_effect = null;
   }
 
-  metadataLoaded() {
-    return this.metadataLoaded_;
-  }
-
   preload() {
     // Retrieves JSON metadata for songs
     // TODO: only load song data when necessary and don't hardcode the dev song
-    this.loadDevelopmentSongs_(() => {this.metadataLoaded_ = true});
+    this.loadDevelopmentSongs_();
 
     // Load spritesheet JSON files
     this.world.SPRITE_NAMES.forEach(this_sprite => {
@@ -693,19 +686,15 @@ module.exports = class DanceParty {
     return this.p5_.allSprites.indexOf(sprite) > -1;
   }
 
-  async loadSongMetadata_(id){
+  loadSongMetadata_(id){
     let songDataPath = '/api/v1/sound-library/hoc_song_meta';
-    const response = await fetch(`${songDataPath}/${id}.json`);
-    this.setMetadata_(id, await response.json());
+    this.p5_.loadJSON(`${songDataPath}/${id}.json`, metadata => {
+      this.setMetadata_(id, metadata);
+    });
   }
 
   loadDevelopmentSongs_(callback) {
-    let ids = ['macklemore90', 'hammer', 'peas'];
-
-    Promise.all([this.loadSongMetadata_(ids[0]), this.loadSongMetadata_(ids[1]), this.loadSongMetadata_(ids[2])])
-    .then( () => {
-      callback();
-    });
+    ['macklemore90', 'hammer', 'peas'].forEach(id => this.loadSongMetadata_(id));
   }
 
   setMetadata_(id, data){

--- a/test/unit/sanity.js
+++ b/test/unit/sanity.js
@@ -6,7 +6,6 @@ test('sanity', t => {
   loadP5().then(p5Inst => {
     const nativeAPI = new DanceParty(p5Inst, {});
 
-    t.notOk(nativeAPI.metadataLoaded());
     t.end();
   });
 });


### PR DESCRIPTION
* While modifying the share experience to autoplay, I decided to fix the load path such that it is obvious that dance-party is ready once we exit the p5 `preload()` phase. We can avoid the need for a `metadataLoaded()` and/or a new callback to indicate when metadata loading is complete if we just use `p5.loadJSON()` to load the song metadata.
* The check in `addCues()` to make sure the metadata is loaded is not needed, since `addCues()` is called within the `setup()` phase (after the `preload()` phase is complete)