### PR TITLE
fix node checking so we work on browsers and node

### DIFF
--- a/src/loadP5.js
+++ b/src/loadP5.js
@@ -1,6 +1,6 @@
 let context;
 
-if (typeof global !== undefined) {
+if ((typeof process !== 'undefined') && (process.release) && (process.release.name === 'node')) {
   context = global;
 
   const {JSDOM} = eval("require('jsdom')"); // eslint-disable-line no-eval


### PR DESCRIPTION
* We were failing to load in the browser since webpack started wrapping this code and passing a local variable called `global` - fixed using the technique recommended here: https://github.com/zeit/next.js/issues/219
