### PR TITLE
Export the built dance-party target as a umd module

### DIFF
--- a/demo.js
+++ b/demo.js
@@ -1,0 +1,14 @@
+import DanceParty from './src/p5.dance';
+import jazzy_beats from './metadata/jazzy_beats';
+
+const nativeAPI = window.nativeAPI = new DanceParty({
+  onPuzzleComplete: () => {},
+  playSound: ({callback}) => setTimeout(() => {callback && callback();}, 0),
+  onInit: () => {
+    // Sample user code:
+    nativeAPI.setBackgroundEffect('disco');
+    nativeAPI.makeNewDanceSprite("CAT", null, {x: 200, y: 200});
+
+    nativeAPI.play(jazzy_beats);
+  },
+});

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <script src="./main.js"></script>
+    <script src="./demo.js"></script>
     <title>Dance Party</title>
   </head>
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,5 @@
-import DanceParty from './p5.dance';
-import jazzy_beats from '../metadata/jazzy_beats';
+const DanceParty = require('./p5.dance');
 
-const nativeAPI = window.nativeAPI = new DanceParty({
-  onPuzzleComplete: () => {},
-  playSound: ({callback}) => setTimeout(() => {callback && callback();}, 0),
-  onInit: () => {
-    // Sample user code:
-    nativeAPI.setBackgroundEffect('disco');
-    nativeAPI.makeNewDanceSprite("CAT", null, {x: 200, y: 200});
-
-    nativeAPI.play(jazzy_beats);
-  },
-});
+module.exports = {
+  DanceParty,
+};

--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -30,7 +30,8 @@ module.exports = class DanceParty {
     onPuzzleComplete,
     playSound,
     moveNames,
-    recordReplayLog
+    recordReplayLog,
+    container,
   }) {
     this.onInit = onInit;
 
@@ -90,7 +91,7 @@ module.exports = class DanceParty {
       p5Inst.preload = () => this.preload();
       p5Inst.setup = () => this.setup();
       p5Inst.draw = () => this.draw();
-    });
+    }, container);
   }
 
   getReplayLog() {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  entry: {
+    main: './src/index.js',
+    demo: './demo.js',
+  },
+  output: {
+    filename: '[name].js',
+    libraryTarget: 'umd',
+  },
+};


### PR DESCRIPTION
So we can use the webpack built version of dist/main.js, which should include all the necessary p5 code inlined.