### PR TITLE
Update p5play add events and key support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code-dot-org/dance-party",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "",
   "main": "dist/main.js",
   "scripts": {
@@ -21,13 +21,13 @@
   "author": "",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@code-dot-org/p5.play": "1.3.4-cdo",
+    "@code-dot-org/p5": "0.5.4-cdo",
+    "@code-dot-org/p5.play": "1.3.5-cdo",
     "canvas": "^1.6.13",
     "codecov": "^3.1.0",
     "eslint": "^2.8.0",
     "jsdom": "^12.2.0",
     "nyc": "^13.1.0",
-    "p5": "0.5.4",
     "tape": "^4.9.1",
     "webpack": "4.19.1",
     "webpack-cli": "^2.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code-dot-org/dance-party",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "",
   "main": "dist/main.js",
   "scripts": {
@@ -21,7 +21,6 @@
   "author": "",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@code-dot-org/p5": "0.5.4-cdo",
     "@code-dot-org/p5.play": "1.3.5-cdo",
     "canvas": "^1.6.13",
     "codecov": "^3.1.0",

--- a/src/loadP5.js
+++ b/src/loadP5.js
@@ -1,45 +1,13 @@
-let context;
-
 if ((typeof process !== 'undefined') && (process.release) && (process.release.name === 'node')) {
-  context = global;
-
   const {JSDOM} = eval("require('jsdom')"); // eslint-disable-line no-eval
   global.window = new JSDOM().window;
   global.document = window.document;
   global.screen = window.screen;
   global.Image = window.Image;
-} else {
-  context = window;
 }
 
-const P5 = require('p5');
-
-// const P5 = Object.getPrototypeOf(p5).constructor;
-if (P5.Renderer2D) {
-  /**
-   * Patch p5 tint to use fast compositing (see https://github.com/code-dot-org/p5_play/pull/42).
-   */
-  P5.Renderer2D.prototype._getTintedImageCanvas = function (img) {
-    this._tintCanvas = this._tintCanvas || document.createElement('canvas');
-    this._tintCanvas.width = img.canvas.width;
-    this._tintCanvas.height = img.canvas.height;
-    const tmpCtx = this._tintCanvas.getContext('2d');
-    tmpCtx.fillStyle = 'hsl(' + this._pInst.hue(this._tint) + ', 100%, 50%)';
-    tmpCtx.fillRect(0, 0, this._tintCanvas.width, this._tintCanvas.height);
-    tmpCtx.globalCompositeOperation = 'destination-atop';
-    tmpCtx.drawImage(img.canvas, 0, 0, this._tintCanvas.width, this._tintCanvas.height);
-    tmpCtx.globalCompositeOperation = 'multiply';
-    tmpCtx.drawImage(img.canvas, 0, 0, this._tintCanvas.width, this._tintCanvas.height);
-    return this._tintCanvas;
-  };
-}
+const P5 = require('@code-dot-org/p5');
 P5.disableFriendlyErrors = true;
-
-
-context.define = function (name, dependencies, callback) {
-  callback(P5);
-};
-context.define.amd = true;
 
 require('@code-dot-org/p5.play/lib/p5.play');
 

--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -26,14 +26,18 @@ function randomInt(min, max) {
 
 module.exports = class DanceParty {
   constructor({
+    onHandleEvents,
     onInit,
     onPuzzleComplete,
     playSound,
     moveNames,
     recordReplayLog,
+    showMeasureLabel = true,
     container,
   }) {
+    this.onHandleEvents = onHandleEvents;
     this.onInit = onInit;
+    this.showMeasureLabel = showMeasureLabel;
 
     this.currentFrameEvents = {
       'this.p5_.keyWentDown': {},
@@ -92,6 +96,14 @@ module.exports = class DanceParty {
       p5Inst.setup = () => this.setup();
       p5Inst.draw = () => this.draw();
     }, container);
+  }
+
+  onKeyDown(keyCode) {
+    this.p5_._onkeydown({ which: keyCode });
+  }
+
+  onKeyUp(keyCode) {
+    this.p5_._onkeyup({ which: keyCode });
   }
 
   getReplayLog() {
@@ -775,6 +787,12 @@ module.exports = class DanceParty {
     this.p5_.textSize(20);
 
     this.world.validationCallback(this.world, this, this.sprites_);
-    this.p5_.text("Measure: " + (Math.floor(this.getCurrentMeasure())), 10, 20);
+    if (this.showMeasureLabel) {
+      this.p5_.text("Measure: " + (Math.floor(this.getCurrentMeasure())), 10, 20);
+    }
+
+    if (this.currentFrameEvents.any && this.onHandleEvents) {
+      this.onHandleEvents(this.currentFrameEvents);
+    }
   }
 };


### PR DESCRIPTION
* Cleaned up how we get our version of p5 (it now comes in a sub-dependency of p5.play)
* Add 2 new API methods: `onKeyDown(keyCode)` and `onKeyUp(keyCode)` - these are used to route key events from the host down into dance/p5 (this is used when the host wants soft buttons)
* Add a new `showMeasureLabel` option that defaults to `true` - we are likely to make this `false` in cdo's share mode
* Add the ability for the host to provide an `onHandleEvents` function that will be called each frame as long as there are new events (the host doesn't need to know about `currentFrameEvents` - they will be passed as a param to `onHandleEvents()`)