### PR TITLE
add short burst moves, test hooks, and babel-core dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@code-dot-org/p5.play": "1.3.5-cdo",
+    "babel-core": "^6.26.3",
     "babel-loader": "^7.1.4",
     "babel-preset-env": "^1.7.0",
     "babelify": "^6.3.0",

--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -85,6 +85,12 @@ module.exports = class DanceParty {
       {name: "Roll", mirror: true},
       {name: "ThisOrThat", mirror: false},
       {name: "Thriller", mirror: true},
+      {name: "XArmsSide", mirror: true},
+      {name: "XArmsUp", mirror: true},
+      {name: "XJump", mirror: true},
+      {name: "XClapSide", mirror: true},
+      {name: "XHeadHips", mirror: true},
+      {name: "XHighKick", mirror: true},
     ];
 
     if (spriteConfig) {
@@ -199,6 +205,9 @@ module.exports = class DanceParty {
     this.analysisPosition_ = 0;
     this.playSound_({url: this.songMetadata_.file, callback: () => {this.songStartTime_ = new Date()}});
     this.p5_.loop();
+
+    /** Expose for testing **/
+    window.__mostRecentDancePartySongUrl = this.songMetadata_.file;
   }
 
   setBackground(color) {
@@ -798,5 +807,8 @@ module.exports = class DanceParty {
     if (this.currentFrameEvents.any && this.onHandleEvents) {
       this.onHandleEvents(this.currentFrameEvents);
     }
+
+    /** Expose for testing **/
+    window.__mostRecentDancePartySpriteCount = this.p5_.allSprites.length;
   }
 };


### PR DESCRIPTION
* We now have "short burst" moves uploaded for all characters except pineapple and alien (which are using placeholder cat animations with the expected filenames). Adding these to `MOVE_NAMES` so we can expose them with blocks. Testing has verified that we can load all of these moves within the RAM limits on a "low end" device (verified on iPad Mini 2 with iOS 10.1.1 and on iPhone 5s with iOS 12.0.1).
* Added test hooks to make it easier to detect the number of sprites and the song playing from within UI tests: `window.__mostRecentDancePartySongUrl` and `window.__mostRecentDancePartySpriteCount`
* Explicitly added `babel-core` as a dev dependency. This makes our project compatible with `yarn` as well as `npm`