### PR TITLE
Handle collision with atTimestamp and everyN blocks

### DIFF
--- a/levels/spriteDance.js
+++ b/levels/spriteDance.js
@@ -1,0 +1,170 @@
+module.exports = {
+  collisionEveryNMeasure: {
+    solutions: [
+      `
+      var lead_dancer;
+
+      whenSetup(function () {
+        lead_dancer = makeNewDanceSprite("CAT", lead_dancer, {x: 200, y: 200});
+      });
+      
+      everySeconds(1, "measures", function () {
+        changeMoveLR(lead_dancer, 3, -1);
+      });
+      
+      everySeconds(2, "measures", function () {
+        changeMoveLR(lead_dancer, 1, -1);
+      });
+    `,
+      `
+      var lead_dancer;
+
+      whenSetup(function () {
+        lead_dancer = makeNewDanceSprite("CAT", lead_dancer, {x: 200, y: 200});
+      });
+      
+      everySeconds(2, "measures", function () {
+        changeMoveLR(lead_dancer, 1, -1);
+      });
+      
+      everySeconds(1, "measures", function () {
+        changeMoveLR(lead_dancer, 3, -1);
+      });
+    `,
+    ],
+    validationCode: `
+      if (nativeAPI.getTime("measures") === 2) {
+        let cats = nativeAPI.getGroupByName_('CAT');
+        for(let i = 0; i < cats.length; i++){
+          if(cats[i].current_move !== 1){
+            nativeAPI.fail("Cat sprite not dancing 1."); 
+          }
+        }
+      }
+      if (nativeAPI.getTime("measures") === 3) {
+        let cats = nativeAPI.getGroupByName_('CAT');
+        for(let i = 0; i < cats.length; i++){
+          if(cats[i].current_move !== 3){
+            nativeAPI.fail("Cat sprite not dancing 3."); 
+          }
+        }
+      }
+      
+      if (nativeAPI.getTime("measures") > 7) {
+        nativeAPI.pass();
+      }
+    `,
+  },
+  collisionEveryNSeconds: {
+    solutions: [
+      `
+      var lead_dancer;
+
+      whenSetup(function () {
+        lead_dancer = makeNewDanceSprite("CAT", lead_dancer, {x: 200, y: 200});
+      });
+      
+      everySeconds(2, "seconds", function () {
+        changeMoveLR(lead_dancer, 3, -1);
+      });
+      
+      everySeconds(5, "seconds", function () {
+        changeMoveLR(lead_dancer, 1, -1);
+      });
+    `,
+      `
+      var lead_dancer;
+
+      whenSetup(function () {
+        lead_dancer = makeNewDanceSprite("CAT", lead_dancer, {x: 200, y: 200});
+      });
+      
+      everySeconds(5, "seconds", function () {
+        changeMoveLR(lead_dancer, 1, -1);
+      });
+      
+      everySeconds(2, "seconds", function () {
+        changeMoveLR(lead_dancer, 3, -1);
+      });
+    `,
+    ],
+    validationCode: `
+      if (nativeAPI.getTime("seconds") === 5) {
+        let cats = nativeAPI.getGroupByName_('CAT');
+        for(let i = 0; i < cats.length; i++){
+          if(cats[i].current_move !== 1){
+            nativeAPI.fail("Cat sprite not dancing 1."); 
+          }
+        }
+      }
+      if (nativeAPI.getTime("seconds") === 2) {
+        let cats = nativeAPI.getGroupByName_('CAT');
+        for(let i = 0; i < cats.length; i++){
+          if(cats[i].current_move !== 3){
+            nativeAPI.fail("Cat sprite not dancing 3."); 
+          }
+        }
+      }
+      
+      if (nativeAPI.getTime("seconds") > 7) {
+        nativeAPI.pass();
+      }
+    `,
+  },
+  collisionEveryNMeasureAndTimestamp: {
+    solutions: [
+      `
+      var lead_dancer;
+
+      whenSetup(function () {
+        lead_dancer = makeNewDanceSprite("CAT", lead_dancer, {x: 200, y: 200});
+      });
+      
+      everySeconds(2, "measures", function () {
+        changeMoveLR(lead_dancer, 3, -1);
+      });
+      
+      atTimestamp(2, "measures", function () {
+        changeMoveLR(lead_dancer, 1, -1);
+      });
+    `,
+      `
+      var lead_dancer;
+
+      whenSetup(function () {
+        lead_dancer = makeNewDanceSprite("CAT", lead_dancer, {x: 200, y: 200});
+      });
+      
+      atTimestamp(2, "measures", function () {
+        changeMoveLR(lead_dancer, 1, -1);
+      });
+      
+      everySeconds(2, "measures", function () {
+        changeMoveLR(lead_dancer, 3, -1);
+      });     
+    `,
+    ],
+    validationCode: `
+      if (nativeAPI.getTime("measures") === 2) {
+        let cats = nativeAPI.getGroupByName_('CAT');
+        for(let i = 0; i < cats.length; i++){
+          if(cats[i].current_move !== 1){
+            nativeAPI.fail("Cat sprite not dancing 1."); 
+          }
+        }
+      }
+      if (nativeAPI.getTime("measures") === 4) {
+        let cats = nativeAPI.getGroupByName_('CAT');
+        for(let i = 0; i < cats.length; i++){
+          if(cats[i].current_move !== 3){
+            nativeAPI.fail("Cat sprite not dancing 3."); 
+          }
+        }
+      }
+      
+      if (nativeAPI.getTime("measures") > 5) {
+        nativeAPI.pass();
+      }
+    `,
+  },
+};

--- a/src/p5.dance.interpreted.js
+++ b/src/p5.dance.interpreted.js
@@ -110,10 +110,13 @@ function whenPeak(range, event) {
 }
 
 function atTimestamp(timestamp, unit, event) {
+  // Increment priority by 1 to account for 'atTimestamp' events having a higher priority
+  // than everySecond events when they have share a timestamp parameter
   inputEvents.push({
     type: 'cue-' + unit,
     event: event,
-    param: timestamp
+    param: timestamp,
+    priority: timestamp + 1
   });
 }
 

--- a/test/integration/spriteDanceTest.js
+++ b/test/integration/spriteDanceTest.js
@@ -1,0 +1,51 @@
+const test = require('tape');
+const attempt = require('../helpers/runLevel.js');
+const levels = require('../../levels/spriteDance');
+
+test('Dance collision: every measures - rarer move second', t => {
+  const level = levels.collisionEveryNMeasure;
+  attempt(level.solutions[0], level.validationCode, (result, message) => {
+    t.true(result);
+    t.end();
+  });
+});
+
+test('Dance collision: every measures - rarer move first', t => {
+  const level = levels.collisionEveryNMeasure;
+  attempt(level.solutions[1], level.validationCode, (result, message) => {
+    t.true(result);
+    t.end();
+  });
+});
+
+test('Dance collision: every seconds - rarer move second', t => {
+  const level = levels.collisionEveryNSeconds;
+  attempt(level.solutions[0], level.validationCode, (result, message) => {
+    t.true(result);
+    t.end();
+  });
+});
+
+test('Dance collision: every seconds - rarer move first', t => {
+  const level = levels.collisionEveryNSeconds;
+  attempt(level.solutions[1], level.validationCode, (result, message) => {
+    t.true(result);
+    t.end();
+  });
+});
+
+test('Dance collision: every measures and at timestamp - rarer move second', t => {
+  const level = levels.collisionEveryNSeconds;
+  attempt(level.solutions[0], level.validationCode, (result, message) => {
+    t.true(result);
+    t.end();
+  });
+});
+
+test('Dance collision: every measures and at timestamp - rarer move first', t => {
+  const level = levels.collisionEveryNSeconds;
+  attempt(level.solutions[1], level.validationCode, (result, message) => {
+    t.true(result);
+    t.end();
+  });
+});


### PR DESCRIPTION
In PR: https://github.com/code-dot-org/code-dot-org/pull/25635 we introduced the idea of priority to handle collisions between EveryN[seconds, measures] blocks. This PR extends priority to include atTimestamp blocks.

Per discussion with Ryan - atTimestamp blocks should get priority over everyN blocks. This uses their timestamp as priority similar to #25635, but artificially increments it by 1, so that atTimestamp blocks will have a slightly higher priority than everyN blocks that are registered to the same time stamp.

PR includes integration tests that confirm the dance with the expected priority is shown when blocks collide.