### PR TITLE
Add test hook interface

### DIFF
--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -124,6 +124,14 @@ module.exports = class DanceParty {
     }
   }
 
+  getTestInterface() {
+    return {
+      getSprites: () => this.p5_ && this.p5_.allSprites,
+      getSongUrl: () => this.songMetadata_ && this.songMetadata_.file,
+      getSongStartedTime: () => this.songStartTime_,
+    };
+  }
+
   pass() {
     this.onPuzzleComplete_(true);
   }

--- a/test/unit/testInterfaceTest.js
+++ b/test/unit/testInterfaceTest.js
@@ -1,0 +1,24 @@
+const test = require('tape');
+const helpers = require('../helpers/createDanceAPI');
+
+test('testInterface getSprites', async t => {
+  const nativeAPI = await helpers.createDanceAPI();
+  const testInterface = nativeAPI.getTestInterface();
+
+  t.equal(testInterface.getSprites().length, 0);
+
+  nativeAPI.play({
+    bpm: 120,
+  });
+
+  t.equal(testInterface.getSprites().length, 0);
+
+  nativeAPI.setAnimationSpriteSheet("CAT", 0, {}, () => {});
+  const sprite = nativeAPI.makeNewDanceSprite("CAT", null, {x: 200, y: 200});
+  
+  t.equal(testInterface.getSprites().length, 1);
+  t.equal(testInterface.getSprites()[0], sprite);
+
+  t.end();
+  nativeAPI.reset();
+});


### PR DESCRIPTION
* Add a new test interface via `DanceParty.getTestInterface()` that will allow test code in the `code-dot-org` repo to access some of the internal state of `DanceParty` without poking into private properties and methods that are subject to change.
* The interface currently consists of `getSprites()`, `getSongUrl()`, and `getSongStartedTime()` - and can be extended over time.