### PR TITLE
Adds group `setTint` and `setVisible` functions

### DIFF
--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -477,6 +477,10 @@ module.exports = class DanceParty {
     this.setProp(sprite, "tint", val);
   }
 
+  setVisible(sprite, val) {
+    this.setProp(sprite, "visible", val);
+  }
+
   setProp(sprite, property, val) {
     if (!this.spriteExists_(sprite) || val === undefined) return;
 
@@ -531,6 +535,14 @@ module.exports = class DanceParty {
 
   changePropBy(sprite,  property, val) {
     this.setProp(sprite, property, this.getProp(sprite, property) + val);
+  }
+
+  setTintEach(group, val) {
+    this.setPropEach(group, "tint", val);
+  }
+
+  setVisibleEach(group, val) {
+    this.setPropEach(group, "visible", val);
   }
 
   setPropEach(group, property, val) {

--- a/test/unit/groupTest.js
+++ b/test/unit/groupTest.js
@@ -26,6 +26,33 @@ test('changing dance moves for all updates all dancers', async t => {
   nativeAPI.reset();
 });
 
+test('changing visibility for all updates all dancers', async t => {
+  const nativeAPI = await helpers.createDanceAPI();
+  nativeAPI.play({
+    bpm: 120,
+  });
+  nativeAPI.setAnimationSpriteSheet("CAT", 0, {}, () => {});
+  nativeAPI.setAnimationSpriteSheet("BEAR", 0, {}, () => {});
+
+  const catSprite = nativeAPI.makeNewDanceSprite("CAT", null, {x: 200, y: 200});
+  const bearSprite = nativeAPI.makeNewDanceSprite("BEAR", null, {x: 200, y: 200});
+
+  t.equal(catSprite.visible, true);
+  t.equal(bearSprite.visible, true);
+
+  nativeAPI.setVisibleEach('all', false);
+  t.equal(nativeAPI.getProp(catSprite, 'visible'), false);
+  t.equal(nativeAPI.getProp(bearSprite, 'visible'), false);
+
+  nativeAPI.setTintEach('all', 'blue');
+  t.equal(nativeAPI.getProp(catSprite, 'tint'), 240);
+  t.equal(nativeAPI.getProp(bearSprite, 'tint'), 240);
+
+  t.end();
+
+  nativeAPI.reset();
+});
+
 test('changing dance moves for all cats updates only all cat dancers', async t => {
   const nativeAPI = await helpers.createDanceAPI();
   nativeAPI.play({


### PR DESCRIPTION
Went in to add `setVisible` and `setVisibleEach`, noticed that we didn't have a group friendly `setTint` and added that in as well.

Side note, these are all effectively blocks we already have but with one param hardcoded - would be nice if we could account for this in the block XML instead of needing to add a helper function for each one.