### PR TITLE
Fix setBackground

### DIFF
--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -220,6 +220,8 @@ module.exports = class DanceParty {
   }
 
   setBackground(color) {
+    // Clear background effect so it doesn't cover up background color.
+    this.world.bg_effect = this.bgEffects_.none;
     this.world.background_color = color;
   }
 

--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -792,7 +792,7 @@ module.exports = class DanceParty {
       bpm: this.songMetadata_ && this.songMetadata_.bpm,
     };
 
-    this.p5_.background("white");
+    this.p5_.background(this.world.background_color || "white");
     if (this.world.bg_effect && this.world.fg_effect !== this.fgEffects_.none) {
       this.world.bg_effect.draw(context);
     }


### PR DESCRIPTION
Fixes #77.

There are two parts to this fix:
- If `bg_effect` isn't set when we call `draw()`, we don't call `this.world.bg_effect.draw(context)`, so background color (which is in context) doesn't get set. _Solution: Set p5 background color to `this.world.background_color` if it is set._
- If `bg_effect` is set when `setBackground(color)` was called, the background effect "wins" and the new background color isn't visible. _Solution: Clear the background effect (set `bg_effect` to "none") when setting a background color._