### PR TITLE
expose callback on play()

### DIFF
--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -209,13 +209,16 @@ module.exports = class DanceParty {
     this.onInit && this.onInit(this);
   }
 
-  play(songData) {
+  play(songData, callback) {
     if (this.recordReplayLog_) {
       replayLog.reset();
     }
     this.songMetadata_ = songData;
     this.analysisPosition_ = 0;
-    this.playSound_({url: this.songMetadata_.file, callback: () => {this.songStartTime_ = new Date()}});
+    this.playSound_({url: this.songMetadata_.file, callback: () => {
+      this.songStartTime_ = new Date();
+      callback && callback();
+    }});
     this.p5_.loop();
   }
 


### PR DESCRIPTION
* Part of the fix for https://github.com/code-dot-org/dance-party/issues/39 requires that we know when the song is actually playing (upstream where we have the Run and Reset button). Expose the `playSound()` callback through `DanceParty.play()`