### PR TITLE
short burst and rand fixes

### DIFF
--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -24,6 +24,7 @@ const SIZE = 300;
 const ANIMATIONS = {};
 const FRAMES = 24;
 
+// NOTE: min and max are inclusive
 function randomInt(min, max) {
   return Math.floor(Math.random() * (max - min + 1)) + min;
 }
@@ -77,7 +78,7 @@ module.exports = class DanceParty {
     this.world.SPRITE_NAMES = ["ALIEN", "BEAR", "CAT", "DOG", "DUCK", "FROG", "MOOSE", "PINEAPPLE", "ROBOT", "SHARK", "UNICORN"];
 
     this.world.MOVE_NAMES = moveNames || [
-      {name: "Rest", mirror: true},
+      {name: "Rest", mirror: true, rest: true},
       {name: "ClapHigh", mirror: true},
       {name: "Clown", mirror: false},
       {name: "Dab", mirror: true},
@@ -89,17 +90,25 @@ module.exports = class DanceParty {
       {name: "Roll", mirror: true},
       {name: "ThisOrThat", mirror: false},
       {name: "Thriller", mirror: true},
-      {name: "XArmsSide", mirror: false},
-      {name: "XArmsUp", mirror: false},
-      {name: "XJump", mirror: false},
-      {name: "XClapSide", mirror: false},
-      {name: "XHeadHips", mirror: false},
-      {name: "XHighKick", mirror: false},
+      {name: "XArmsSide", mirror: false, shortBurst: true},
+      {name: "XArmsUp", mirror: false, shortBurst: true},
+      {name: "XJump", mirror: false, shortBurst: true},
+      {name: "XClapSide", mirror: false, shortBurst: true},
+      {name: "XHeadHips", mirror: false, shortBurst: true},
+      {name: "XHighKick", mirror: false, shortBurst: true},
     ];
 
     if (spriteConfig) {
       spriteConfig(this.world);
     }
+
+    // Sort after spriteConfig function has executed to ensure that
+    // rest moves are at the beginning and shortBurst moves are all at the end
+    this.world.MOVE_NAMES = this.world.MOVE_NAMES.sort((move1, move2) => (
+      move1.rest * -2 * move2.rest * 2 + move2.shortBurst * -1 + move1.shortBurst * 1
+    ));
+    this.world.restMoveCount = this.world.MOVE_NAMES.filter(move => move.rest).length;
+    this.world.fullLengthMoveCount = this.world.MOVE_NAMES.filter(move => !move.shortBurst).length;
 
     this.songStartTime_ = 0;
 
@@ -294,7 +303,9 @@ module.exports = class DanceParty {
         }
 
         if (sprite.looping_frame % FRAMES === 0) {
-          if (ANIMATIONS[sprite.style][sprite.current_move].mirror) sprite.mirroring *= -1;
+          if (ANIMATIONS[sprite.style][sprite.current_move].mirror) {
+            sprite.mirroring *= -1;
+          }
           if (sprite.animation.looping) {
             sprite.mirrorX(sprite.mirroring);
           }
@@ -344,32 +355,56 @@ module.exports = class DanceParty {
 // Dance Moves
 
   changeMoveLR(sprite, move, dir) {
-    if (!this.spriteExists_(sprite)) return;
-    if (move === "next") {
-      move = 1 + (sprite.current_move % (ANIMATIONS[sprite.style].length - 1));
-    } else if (move === "prev") {
-      //Javascript doesn't handle negative modulos as expected, so manually resetting the loop
-      move = sprite.current_move - 1;
-      if (move <= 0) {
-        move = ANIMATIONS[sprite.style].length - 1;
+    if (!this.spriteExists_(sprite)) {
+      return;
+    }
+    // Number of valid full length moves
+    const { fullLengthMoveCount, restMoveCount } = this.world;
+    const firstNonRestingMoveIndex = restMoveCount;
+    // The "rest" moves are assumed to always be at the beginning
+    const nonRestingFullLengthMoveCount = fullLengthMoveCount - restMoveCount;
+    if (typeof move === 'number') {
+      if (move < 0 || move >= fullLengthMoveCount) {
+        throw("Not moving to a valid full length move index!");
       }
-    } else if (move === "rand") {
-      // Make sure random switches to a new move
-      move = sprite.current_move;
-      while (move === sprite.current_move) {
-        move = randomInt(0, ANIMATIONS[sprite.style].length - 1);
+    } else {
+      if (nonRestingFullLengthMoveCount <= 1) {
+        throw("next/prev/rand requires that we have 2 or more non-resting full length moves");
+      }
+      if (move === "next") {
+        move = sprite.current_move + 1;
+        if (move >= fullLengthMoveCount) {
+          move = firstNonRestingMoveIndex;
+        }
+      } else if (move === "prev") {
+        move = sprite.current_move - 1;
+        if (move < firstNonRestingMoveIndex) {
+          move = fullLengthMoveCount - 1;
+        }
+      } else if (move === "rand") {
+        // Make sure random switches to a new move
+        move = sprite.current_move;
+        while (move === sprite.current_move) {
+          move = randomInt(firstNonRestingMoveIndex, fullLengthMoveCount - 1);
+        }
+      } else {
+        throw(`Unexpected move value: ${move}`);
       }
     }
     sprite.mirroring = dir;
     sprite.mirrorX(dir);
     sprite.changeAnimation("anim" + move);
-    if (sprite.animation.looping) sprite.looping_frame = 0;
+    if (sprite.animation.looping) {
+      sprite.looping_frame = 0;
+    }
     sprite.animation.looping = true;
     sprite.current_move = move;
   }
 
   doMoveLR(sprite, move, dir) {
-    if (!this.spriteExists_(sprite)) return;
+    if (!this.spriteExists_(sprite)) {
+      return;
+    }
     if (move === "next") {
       move = (sprite.current_move + 1) % ANIMATIONS[sprite.style].length;
     } else if (move === "prev") {
@@ -380,10 +415,15 @@ module.exports = class DanceParty {
         move = randomInt(0, ANIMATIONS[sprite.style].length - 1);
       }
     }
+    if (move < 0 || move >= this.world.MOVE_NAMES.length) {
+      throw(`Invalid move index: ${move}`);
+    }
     sprite.mirrorX(dir);
     sprite.changeAnimation("anim" + move);
     sprite.animation.looping = false;
-    sprite.animation.changeFrame(FRAMES / 2);
+    // For non-shortBurst, we jump to the middle of the animation
+    const frameNum = this.world.MOVE_NAMES[move].shortBurst ? 0 : (FRAMES / 2);
+    sprite.animation.changeFrame(frameNum);
   }
 
   getCurrentDance(sprite) {

--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -365,11 +365,11 @@ module.exports = class DanceParty {
     const nonRestingFullLengthMoveCount = fullLengthMoveCount - restMoveCount;
     if (typeof move === 'number') {
       if (move < 0 || move >= fullLengthMoveCount) {
-        throw("Not moving to a valid full length move index!");
+        throw "Not moving to a valid full length move index!";
       }
     } else {
       if (nonRestingFullLengthMoveCount <= 1) {
-        throw("next/prev/rand requires that we have 2 or more non-resting full length moves");
+        throw "next/prev/rand requires that we have 2 or more non-resting full length moves";
       }
       if (move === "next") {
         move = sprite.current_move + 1;
@@ -388,7 +388,7 @@ module.exports = class DanceParty {
           move = randomInt(firstNonRestingMoveIndex, fullLengthMoveCount - 1);
         }
       } else {
-        throw(`Unexpected move value: ${move}`);
+        throw `Unexpected move value: ${move}`;
       }
     }
     sprite.mirroring = dir;
@@ -416,7 +416,7 @@ module.exports = class DanceParty {
       }
     }
     if (move < 0 || move >= this.world.MOVE_NAMES.length) {
-      throw(`Invalid move index: ${move}`);
+      throw `Invalid move index: ${move}`;
     }
     sprite.mirrorX(dir);
     sprite.changeAnimation("anim" + move);

--- a/test/helpers/runLevel.js
+++ b/test/helpers/runLevel.js
@@ -38,11 +38,18 @@ module.exports = (userCode, validationCode, onPuzzleComplete) => {
       const {runUserSetup, runUserEvents, getCueList} = new ctor().apply(null, args);
 
       // Mock 4 cat and moose animation poses.
-      for(let i = 0; i < 10; i++) {
+      const moveCount = 10;
+      for(let i = 0; i < moveCount; i++) {
         api.setAnimationSpriteSheet("CAT", i, {}, () => {});
         api.setAnimationSpriteSheet("MOOSE", i, {}, () => {});
         api.setAnimationSpriteSheet("ROBOT", i, {}, () => {});
+        api.world.MOVE_NAMES.push({
+          name: `move${i}`
+        });
       }
+
+      api.world.fullLengthMoveCount = moveCount;
+      api.world.restMoveCount = 1;
 
       api.addCues(getCueList());
       api.onHandleEvents = currentFrameEvents => runUserEvents(currentFrameEvents);

--- a/test/unit/groupTest.js
+++ b/test/unit/groupTest.js
@@ -10,6 +10,12 @@ test('changing dance moves for all updates all dancers', async t => {
   nativeAPI.setAnimationSpriteSheet("CAT", 1, {}, () => {});
   nativeAPI.setAnimationSpriteSheet("BEAR", 0, {}, () => {});
   nativeAPI.setAnimationSpriteSheet("BEAR", 1, {}, () => {});
+  nativeAPI.world.MOVE_NAMES = [
+    { name: `move1` },
+    { name: `move2` },
+  ];
+  nativeAPI.world.fullLengthMoveCount = nativeAPI.world.MOVE_NAMES.length;
+  nativeAPI.world.restMoveCount = 1;
 
   const catSprite = nativeAPI.makeNewDanceSprite("CAT", null, {x: 200, y: 200});
   const bearSprite = nativeAPI.makeNewDanceSprite("BEAR", null, {x: 200, y: 200});
@@ -62,6 +68,12 @@ test('changing dance moves for all cats updates only all cat dancers', async t =
   nativeAPI.setAnimationSpriteSheet("CAT", 1, {}, () => {});
   nativeAPI.setAnimationSpriteSheet("BEAR", 0, {}, () => {});
   nativeAPI.setAnimationSpriteSheet("BEAR", 1, {}, () => {});
+  nativeAPI.world.MOVE_NAMES = [
+    { name: `move1` },
+    { name: `move2` },
+  ];
+  nativeAPI.world.fullLengthMoveCount = nativeAPI.world.MOVE_NAMES.length;
+  nativeAPI.world.restMoveCount = 1;
 
   const catSpriteAlpha = nativeAPI.makeNewDanceSprite("CAT", null, {x: 200, y: 200});
   const catSpriteBeta = nativeAPI.makeNewDanceSprite("CAT", null, {x: 200, y: 200});

--- a/test/unit/spriteManipulation.js
+++ b/test/unit/spriteManipulation.js
@@ -8,9 +8,15 @@ test('Sprite dance decrements and loops for prev dance', async t => {
   });
 
   // Mock 4 cat animation poses
-  for(let i = 0; i < 4; i++) {
+  const moveCount = 4;
+  for(let i = 0; i < moveCount; i++) {
     nativeAPI.setAnimationSpriteSheet("CAT", i, {}, () => {});
+    nativeAPI.world.MOVE_NAMES.push({
+      name: `move${i}`
+    })
   }
+  nativeAPI.world.fullLengthMoveCount = moveCount;
+  nativeAPI.world.restMoveCount = 1;
 
   const sprite = nativeAPI.makeNewDanceSprite("CAT", null, {x: 200, y: 200});
 
@@ -34,9 +40,15 @@ test('Sprite dance increments by one and loops for next dance', async t => {
   });
 
   // Mock 3 cat animation poses
-  for(let i = 0; i < 3; i++) {
+  const moveCount = 3;
+  for(let i = 0; i < moveCount; i++) {
     nativeAPI.setAnimationSpriteSheet("CAT", i, {}, () => {});
+    nativeAPI.world.MOVE_NAMES.push({
+      name: `move${i}`
+    })
   }
+  nativeAPI.world.fullLengthMoveCount = moveCount;
+  nativeAPI.world.restMoveCount = 1;
 
   const sprite = nativeAPI.makeNewDanceSprite("CAT", null, {x: 200, y: 200});
 
@@ -65,9 +77,15 @@ test('Sprite dance changes to a new dance for random', async t => {
   });
 
   // Mock 3 cat animation poses
-  for(let i = 0; i < 3; i++) {
+  const moveCount = 3;
+  for(let i = 0; i < moveCount; i++) {
     nativeAPI.setAnimationSpriteSheet("CAT", i, {}, () => {});
+    nativeAPI.world.MOVE_NAMES.push({
+      name: `move${i}`
+    })
   }
+  nativeAPI.world.fullLengthMoveCount = moveCount;
+  nativeAPI.world.restMoveCount = 1;
 
   const sprite = nativeAPI.makeNewDanceSprite("CAT", null, {x: 200, y: 200});
 

--- a/test/unit/spriteManipulation.js
+++ b/test/unit/spriteManipulation.js
@@ -99,6 +99,158 @@ test('Sprite dance changes to a new dance for random', async t => {
   nativeAPI.reset();
 });
 
+test('Sprite dance changes with next/prev/rand avoids rest dance', async t => {
+
+  const subTest = async testCode => {
+    const nativeAPI = await helpers.createDanceAPI();
+    nativeAPI.play({
+      bpm: 120,
+    });
+  
+    // Mock 3 cat animation poses
+    const moveCount = 3;
+    for(let i = 0; i < moveCount; i++) {
+      nativeAPI.setAnimationSpriteSheet("CAT", i, {}, () => {});
+      nativeAPI.world.MOVE_NAMES.push({
+        name: `move${i}`,
+        rest: i == 0,
+      })
+    }
+    nativeAPI.world.fullLengthMoveCount = moveCount;
+    nativeAPI.world.restMoveCount = 1;
+  
+    const sprite = nativeAPI.makeNewDanceSprite("CAT", null, {x: 200, y: 200});  
+
+    testCode({ nativeAPI, sprite });
+
+    nativeAPI.reset();
+  }
+
+  // Verify Next behavior:
+  await subTest(({ nativeAPI, sprite }) => {
+    // Initial value
+    t.equal(sprite.current_move, 0);
+    nativeAPI.changeMoveLR(sprite, 'next', 1);
+    // Index 1
+    t.equal(sprite.current_move, 1);
+    nativeAPI.changeMoveLR(sprite, 'next', 1);
+    // Index 2
+    t.equal(sprite.current_move, 2);
+    nativeAPI.changeMoveLR(sprite, 'next', 1);
+    // Loops back to index 1 (skipping 0, which is the rest dance)
+    t.equal(sprite.current_move, 1);
+  });
+
+  // Verify Prev behavior:
+  await subTest(({ nativeAPI, sprite }) => {
+    // Initial value
+    t.equal(sprite.current_move, 0);
+    nativeAPI.changeMoveLR(sprite, 'prev', 1);
+    // Index 2
+    t.equal(sprite.current_move, 2);
+    nativeAPI.changeMoveLR(sprite, 'prev', 1);
+    // Index 1
+    t.equal(sprite.current_move, 1);
+    nativeAPI.changeMoveLR(sprite, 'prev', 1);
+    // Loops back to index 2 (skipping 0, which is the rest dance)
+    t.equal(sprite.current_move, 2);
+  });
+
+  // Verify Rand behavior:
+  await subTest(({ nativeAPI, sprite }) => {
+    // Initial value
+    t.equal(sprite.current_move, 0);
+    nativeAPI.changeMoveLR(sprite, 1, 1);
+    // Index 1
+    t.equal(sprite.current_move, 1);
+    nativeAPI.changeMoveLR(sprite, 'rand', 1);
+    // Must be Index 2 (must be different and not 0, which is the rest dance)
+    t.equal(sprite.current_move, 2);
+    nativeAPI.changeMoveLR(sprite, 'rand', 1);
+    // Must be Index 1 (must be different and not 0, which is the rest dance)
+    t.equal(sprite.current_move, 1);
+  });
+
+  t.end();
+});
+
+test('Sprite dance changes will throw with invalid parameters', async t => {
+
+  const subTest = async ({ moveCount = 3, testCode }) => {
+    const nativeAPI = await helpers.createDanceAPI();
+    nativeAPI.play({
+      bpm: 120,
+    });
+  
+    // Mock cat animation poses
+    for(let i = 0; i < moveCount; i++) {
+      nativeAPI.setAnimationSpriteSheet("CAT", i, {}, () => {});
+      nativeAPI.world.MOVE_NAMES.push({
+        name: `move${i}`,
+        rest: i == 0,
+      })
+    }
+    nativeAPI.world.fullLengthMoveCount = moveCount;
+    nativeAPI.world.restMoveCount = 1;
+  
+    const sprite = nativeAPI.makeNewDanceSprite("CAT", null, {x: 200, y: 200});  
+
+    testCode({ nativeAPI, sprite });
+
+    nativeAPI.reset();
+  }
+
+  // Verify invalid string parameter behavior:
+  await subTest({ testCode: ({ nativeAPI, sprite }) => {
+    let error = null;
+    try {
+      // Passing 'some_string' should fail
+      nativeAPI.changeMoveLR(sprite, 'some_string', 1);
+    } catch (e) {
+      error = e;
+    }
+    t.notEqual(error, null, "invalid string parameter");
+  }});
+
+  // Verify invalid move index behavior for changeMoveLR():
+  await subTest({ testCode: ({ nativeAPI, sprite }) => {
+    let error = null;
+    try {
+      // Passing 3 should fail (index is too large)
+      nativeAPI.changeMoveLR(sprite, 3, 1);
+    } catch (e) {
+      error = e;
+    }
+    t.notEqual(error, null, "invalid move index for changeMoveLR");
+  }});
+
+  // Verify invalid rand move because we don't have any different, non-resting moves:
+  await subTest({ moveCount: 2, testCode: ({ nativeAPI, sprite }) => {
+    let error = null;
+    try {
+      // Passing 'rand' should fail
+      nativeAPI.changeMoveLR(sprite, 'rand', 1);
+    } catch (e) {
+      error = e;
+    }
+    t.notEqual(error, null, "invalid rand move");
+  }});
+
+  // Verify invalid move index behavior for doMoveLR():
+  await subTest({ testCode: ({ nativeAPI, sprite }) => {
+    let error = null;
+    try {
+      // Passing 3 should fail (index is too large)
+      nativeAPI.doMoveLR(sprite, 3, 1);
+    } catch (e) {
+      error = e;
+    }
+    t.notEqual(error, null, "invalid move index for doMoveLR");
+  }});
+
+  t.end();
+});
+
 test('getCurrentDance returns current move value for initialized sprite and undefined for uninitialized sprite', async t => {
   const nativeAPI = await helpers.createDanceAPI();
   nativeAPI.play({

--- a/test/unit/spriteManipulation.js
+++ b/test/unit/spriteManipulation.js
@@ -297,21 +297,23 @@ test('Sprite dance changes will allow short burst moves for doMoveLR but not cha
   await subTest({ testCode: ({ nativeAPI, sprite }) => {
     // Full length move:
     nativeAPI.changeMoveLR(sprite, 1, 1);
+    t.equal(sprite.getAnimationLabel(), 'anim1');
     t.equal(sprite.current_move, 1);
 
     // Rest move:
     nativeAPI.changeMoveLR(sprite, 0, 1);
+    t.equal(sprite.getAnimationLabel(), 'anim0');
     t.equal(sprite.current_move, 0);
 
     // Short burst move:
     let error = null;
     try {
-      // Passing 3 should fail (index is too large)
       nativeAPI.changeMoveLR(sprite, 2, 1);
     } catch (e) {
       error = e;
     }
     t.notEqual(error, null, "short burst move should fail with changeMoveLR");
+    t.equal(sprite.getAnimationLabel(), 'anim0');
     t.equal(sprite.current_move, 0);
   }});
 


### PR DESCRIPTION
* Fixing this: https://github.com/code-dot-org/dance-party/issues/87
* We had some special behavior that needed to be cleaned up for maintenance / readability:
  * `next` / `prev` / `rand` on `changeMoveLR()` (do forever) are supposed to exclude the "resting" animation.
    * Cleaned up how we determine which animation(s) are "resting" and make it more explicit (rather than magical `1 +` and `<= 0` conditions) : we now have `restMoveCount`
    * Fixed `rand` to be consistent with `next` and `prev` (confirmed with @mrjoshida )
  * `next` / `prev` / `rand` are supposed to exclude "short burst" animations altogether.
    * In a similar way, cleaned up how we determine which animations are safe to switch between : we now have `fullLengthMoveCount`, which include "resting" move(s)
* `doMoveLR()` (do once) had some special code to jump into the middle of the animation (`FRAMES / 2`) that should not apply to short burst moves since they have only half of the frames. That is now fixed.
* Updated tests that bypass the normal init flow to ensure that `this.world.MOVE_NAMES[]` and the new `this.world.fullLengthMoveCount` and `this.world.restMoveCount` properties are set reasonably so the test will run and pass as expected
