### PR TITLE
remap energy data

### DIFF
--- a/src/modifySongData.js
+++ b/src/modifySongData.js
@@ -1,0 +1,81 @@
+function clamp(min, max, val) {
+  return Math.max(
+    min,
+    Math.min(max, val)
+  );
+}
+
+function calculateMean(vals) {
+  let sum = vals.reduce((sum, cur) => sum + cur, 0);
+  return sum / vals.length;
+}
+
+/**
+ * This method takes an input list of energy values, and outputs a new list. THe
+ * methodology for figuring out the new list is to calculate the mean and standard
+ * deviation of the input values (ignoring zeros). We then define a new range
+ * consisting of some number of standard deviations in either direction from the
+ * mean. Old values are then clamped to our new range, and normalized. Finally
+ * we do some smoothing between frames, based on our smooth factor
+ * @param {number[]} energy - A list of energy values for a single frequency band
+ *   (i.e. bass, mid, high) with values ranging from 0, 255
+ * @param {number} numDeviations - How many standard deviations in either direction
+ *   from the mean we want to include in our new range
+ * @param {number} smoothFactor - What percentage of previous frames to average
+ *   into next frame (should be a number between 0 and 1
+ */
+function getFrequencyEnergy(energy, numDeviations=1.5, smoothFactor=0.7) {
+  const nonZero = energy.filter(e => e > 0);
+  const mean = calculateMean(nonZero);
+
+  const stdDev = Math.sqrt(
+    calculateMean(nonZero.map(x => Math.pow(mean - x, 2)))
+  );
+
+  const min = mean - stdDev * numDeviations;
+  const max = mean + stdDev * numDeviations;
+
+  const ret = energy.map(x => (clamp(min, max, x) - min) / (max - min) * 0xff);
+  return smooth(ret, smoothFactor);
+}
+
+/**
+ * Smooths out an array frame by frame. Each new frame consists of smoothFactor
+ * percent of the previous frame and (1-smoothFactor) percent of the current frame
+ * This method mutates the input rg
+ * @param {number[]} rg
+ * @param {number} smoothFactor
+ */
+function smooth(rg, smoothFactor) {
+  for (let i = 1; i < rg.length; i++) {
+    rg[i] = rg[i-1] * smoothFactor + rg[i] * (1 - smoothFactor);
+  }
+  return rg;
+}
+
+/**
+ * This method takes our song data and modifies the energy values. In an ideal
+ * world (and hopefully in the future) this happens as part of our pre-render
+ * pipeline, but for now it's easier to do this at runtime than it is for us to
+ * regenerate all of our .json files.
+ */
+function modifySongData(songData, numDeviations=1.5, smoothFactor=0.7) {
+  const { analysis } = songData;
+
+  // One thing to note with the approach we've chosen: each song/energy band is
+  // independently normalized around energy 128. This means even if a song is
+  // very base heavy, the average bass and average treble will end up being the
+  // same.
+  const bass = getFrequencyEnergy(analysis.map(x => x.energy[0]), numDeviations, smoothFactor);
+  const mid = getFrequencyEnergy(analysis.map(x => x.energy[1]), numDeviations, smoothFactor);
+  const treble = getFrequencyEnergy(analysis.map(x => x.energy[2]), numDeviations, smoothFactor);
+
+  // Create a new analysis that duplicates each frame, but replaces energy values
+  // with out new ones
+  const newAnalysis = analysis.map((currentFrame, i) => Object.assign({},
+    currentFrame, { energy: [bass[i], mid[i], treble[i]] }));
+
+  return Object.assign({}, songData, { analysis: newAnalysis });
+}
+
+module.exports = modifySongData;

--- a/src/modifySongData.js
+++ b/src/modifySongData.js
@@ -61,6 +61,9 @@ function smooth(rg, smoothFactor) {
  */
 function modifySongData(songData, numDeviations=1.5, smoothFactor=0.7) {
   const { analysis } = songData;
+  if (!analysis) {
+    return songData;
+  }
 
   // One thing to note with the approach we've chosen: each song/energy band is
   // independently normalized around energy 128. This means even if a song is

--- a/src/modifySongData.js
+++ b/src/modifySongData.js
@@ -32,6 +32,13 @@ function getFrequencyEnergy(energy, numDeviations=1.5, smoothFactor=0.7) {
     calculateMean(nonZero.map(x => Math.pow(mean - x, 2)))
   );
 
+  if (stdDev === 0) {
+    // Don't expect this to ever happen, but if it does lets just return our
+    // initial energy rather than divide by zero later
+    console.error('getFrequencyEnergy has standard deviation of zero');
+    return energy;
+  }
+
   const min = mean - stdDev * numDeviations;
   const max = mean + stdDev * numDeviations;
 
@@ -42,6 +49,8 @@ function getFrequencyEnergy(energy, numDeviations=1.5, smoothFactor=0.7) {
 /**
  * Smooths out an array frame by frame. Each new frame consists of smoothFactor
  * percent of the previous frame and (1-smoothFactor) percent of the current frame
+ * This is done so that sprites updates end up being more gradual instead of jerking
+ * around
  * This method mutates the input rg
  * @param {number[]} rg
  * @param {number} smoothFactor
@@ -74,7 +83,7 @@ function modifySongData(songData, numDeviations=1.5, smoothFactor=0.7) {
   const treble = getFrequencyEnergy(analysis.map(x => x.energy[2]), numDeviations, smoothFactor);
 
   // Create a new analysis that duplicates each frame, but replaces energy values
-  // with out new ones
+  // with our new ones
   const newAnalysis = analysis.map((currentFrame, i) => Object.assign({},
     currentFrame, { energy: [bass[i], mid[i], treble[i]] }));
 

--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -4,6 +4,7 @@ const P5 = require('./loadP5');
 const Effects = require('./Effects');
 const replayLog = require('./replay');
 const constants = require('./constants');
+const modifySongData = require('./modifySongData');
 
 function Behavior(func, extraArgs) {
   if (!extraArgs) {
@@ -224,7 +225,7 @@ module.exports = class DanceParty {
     if (this.recordReplayLog_) {
       replayLog.reset();
     }
-    this.songMetadata_ = songData;
+    this.songMetadata_ = modifySongData(songData);
     this.analysisPosition_ = 0;
     this.playSound_({url: this.songMetadata_.file, callback: () => {
       this.songStartTime_ = new Date();

--- a/test/unit/modifySongDataTest.js
+++ b/test/unit/modifySongDataTest.js
@@ -7,16 +7,19 @@ test('can successfully modify song data', t => {
   // make sure we've returned a new object
   t.ok(modified !== songData);
 
+  // pick an arbitrary frame (just needs to be one with non-zero energy)
+  const frame = 1000;
+
   // this is a pretty weak test. just make sure that we're giving different energy values
-  t.notEqual(songData.analysis[100].energy[0], modified.analysis[100].energy[0]);
+  t.notEqual(songData.analysis[frame].energy[0], modified.analysis[frame].energy[0]);
 
   // again pretty weak, but make sure that modifying our params gives us different
   // energy values
   const modifiedSmoothing = modifySongData(songData, 1.5, 0.5);
   const modifiedDeviations = modifySongData(songData, 2, 0.7);
 
-  t.notEqual(modified.analysis[100].energy[0], modifiedSmoothing.analysis[100].energy[0]);
-  t.notEqual(modified.analysis[100].energy[0], modifiedDeviations.analysis[100].energy[0]);
+  t.notEqual(modified.analysis[frame].energy[0], modifiedSmoothing.analysis[frame].energy[0]);
+  t.notEqual(modified.analysis[frame].energy[0], modifiedDeviations.analysis[frame].energy[0]);
 
   t.end();
 });

--- a/test/unit/modifySongDataTest.js
+++ b/test/unit/modifySongDataTest.js
@@ -1,0 +1,22 @@
+const test = require('tape');
+const modifySongData = require('../../src/modifySongData');
+const songData = require('../../metadata/jazzy_beats.json');
+
+test('can successfully modify song data', t => {
+  const modified = modifySongData(songData, 1.5, 0.7);
+  // make sure we've returned a new object
+  t.ok(modified !== songData);
+
+  // this is a pretty weak test. just make sure that we're giving different energy values
+  t.notEqual(songData.analysis[100].energy[0], modified.analysis[100].energy[0]);
+
+  // again pretty weak, but make sure that modifying our params gives us different
+  // energy values
+  const modifiedSmoothing = modifySongData(songData, 1.5, 0.5);
+  const modifiedDeviations = modifySongData(songData, 2, 0.7);
+
+  t.notEqual(modified.analysis[100].energy[0], modifiedSmoothing.analysis[100].energy[0]);
+  t.notEqual(modified.analysis[100].energy[0], modifiedDeviations.analysis[100].energy[0]);
+
+  t.end();
+});


### PR DESCRIPTION
https://github.com/code-dot-org/dance-party/issues/75

We have a block that allows you to make dancers "follow" particular frequency ranges in the music (bass/mid/treble). In many cases there wasn't enough movement for things to be interesting - i.e. we would have some small amount of variation amongst high values in the bass band.

This PR remaps the energy values using a process I describe below. It does that mapping at runtime when you hit play. Ideally, we would actually do this as part of our preRender step, and it would be easy enough to port this code to the preRender pipeline, but that would also mean needing to regenerate a number of new .json files. After discussing with Ryan and Josh, we decided to stick with this approach (willing to be convinced it is wrong).

The Process:
For each frequency band (bass/mid/treble), calculate the mean value, ignoring those entries where the value is zero, and also the standard deviation.

Come up with a new target range that is within N standard deviations of the mean on either side. Clamp values outside of this range to be on the edge (i.e. if our range is 100-200, then value 50 becomes value 100), then normalize back to using the entire range (such that value 50, which got clamped to 100 is now normalized to 0).