### PR TITLE
Load pngquant-optimized spritesheets

### DIFF
--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -175,6 +175,23 @@ module.exports = class DanceParty {
   }
 
   preload() {
+    // Load spritesheets compressed to various levels of quality with pngquant
+    // Pass queryparam ?quality=<quality> to try a particular quality level.
+    // Only those png assets will be downlaoded.
+    // Available quality levels:
+    // 50 - 40% smaller
+    // 25 - 46%
+    // 10 - 51%
+    //  5 - 55%
+    //  1 - 55%
+    //  0 - 63% smaller
+    let qualitySuffix = '-q50'; // Default to q50 for now.  Set to '' to go back to full-quality.
+    const qualitySetting = queryParam('quality');
+    if (qualitySetting) {
+      qualitySuffix = `-q${qualitySetting}`;
+      document.title = `q${qualitySetting} - ${document.title}`;
+    }
+
     // Load spritesheet JSON files
     this.world.SPRITE_NAMES.forEach(this_sprite => {
       ANIMATIONS[this_sprite] = [];
@@ -186,7 +203,7 @@ module.exports = class DanceParty {
           // a canvas creation. This makes it possible to run on mobile Safari in
           // iOS 12 with canvas memory limits.
           this.setAnimationSpriteSheet(this_sprite, moveIndex,
-            this.p5_.loadSpriteSheet(`${baseUrl}.png`, jsonData.frames, true), mirror)
+            this.p5_.loadSpriteSheet(`${baseUrl}${qualitySuffix}.png`, jsonData.frames, true), mirror)
         });
       });
     });
@@ -995,3 +1012,15 @@ module.exports = class DanceParty {
     }
   }
 };
+
+function queryParam(key) {
+  const pair = window.location.search
+    .slice(1)
+    .split('&')
+    .map(pair => pair.split('='))
+    .find(pair => decodeURIComponent(pair[0]) === key);
+  if (pair) {
+    return decodeURIComponent(pair[1]);
+  }
+  return undefined;
+}


### PR DESCRIPTION
Provides access to a number of different spritesheet sets at different pngquant quality levels with a `quality=<?>` queryparam.  Uses the quality=50 setting by default, for a 40% savings in total asset size for all animations.

![image 1](https://user-images.githubusercontent.com/1615761/48034730-6fbcb100-e115-11e8-93e4-3ebddb9dfa83.png)

The key advantages here are smaller download size, and faster startup time.  I checked to see if we get any memory footprint gains from this, but it looks like they are very small (a few megabytes, tops).

This change depends on different quality PNGs I've uploaded to curriculum.code.org with appropriate quality suffixes.

I ran the pngs through pngquant with variations on the following command:

```
pngquant --quality 1-50 --ext "-q50.png" ./*.png
```

The compression results are as such:

```
Compression Total size Savings
-original        15092
-q50              9096     40%
-q25              8180     46%
-q10              7464     51%
-q5               6864     55%
-q1               6796     55%
-q0               5516     63%
```

Showed these in motion to Ryan and he made the call that we'll use q50 for now.  Leaving the other files  around so we can take a look anytime if we decide we want to explore further download size savings.