### PR TITLE
test for draw without data

### DIFF
--- a/test/unit/sanity.js
+++ b/test/unit/sanity.js
@@ -31,3 +31,14 @@ test('i18n', async t => {
 
   nativeAPI.reset();
 });
+
+test('draw without songData', async t => {
+  // we have a valid scenario where draw is called without having set any song
+  // metadata. make sure that we dont hit any exceptions in that path
+  const nativeAPI = await helpers.createDanceAPI();
+  nativeAPI.draw();
+
+  t.end();
+
+  nativeAPI.reset();
+});


### PR DESCRIPTION
This PR adds a very simple test that would have caught the issue that Chris fixed in https://github.com/code-dot-org/dance-party/pull/118.

Validated that the test throws without fix, passes with it.