### PR TITLE
Properly remove behaviors when we stopMapping

### DIFF
--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -794,6 +794,9 @@ module.exports = class DanceParty {
     }
 
     const index = sprite.behaviors.findIndex(b => b.id === behaviorId);
+    if (index === -1) {
+      return;
+    }
     sprite.behaviors.splice(index, 1);
   }
 
@@ -829,6 +832,7 @@ module.exports = class DanceParty {
 
   stopMapping(sprite, property, range) {
     const id = [property, range].join('-');
+    console.log('id: ', id);
     this.removeBehavior_(sprite, id);
   }
 

--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -832,7 +832,6 @@ module.exports = class DanceParty {
 
   stopMapping(sprite, property, range) {
     const id = [property, range].join('-');
-    console.log('id: ', id);
     this.removeBehavior_(sprite, id);
   }
 

--- a/test/unit/spriteManipulation.js
+++ b/test/unit/spriteManipulation.js
@@ -106,7 +106,7 @@ test('Sprite dance changes with next/prev/rand avoids rest dance', async t => {
     nativeAPI.play({
       bpm: 120,
     });
-  
+
     // Mock 3 cat animation poses
     const moveCount = 3;
     for(let i = 0; i < moveCount; i++) {
@@ -118,8 +118,8 @@ test('Sprite dance changes with next/prev/rand avoids rest dance', async t => {
     }
     nativeAPI.world.fullLengthMoveCount = moveCount;
     nativeAPI.world.restMoveCount = 1;
-  
-    const sprite = nativeAPI.makeNewDanceSprite("CAT", null, {x: 200, y: 200});  
+
+    const sprite = nativeAPI.makeNewDanceSprite("CAT", null, {x: 200, y: 200});
 
     testCode({ nativeAPI, sprite });
 
@@ -181,7 +181,7 @@ test('Sprite dance changes will throw with invalid parameters', async t => {
     nativeAPI.play({
       bpm: 120,
     });
-  
+
     // Mock cat animation poses
     for(let i = 0; i < moveCount; i++) {
       nativeAPI.setAnimationSpriteSheet("CAT", i, {}, () => {});
@@ -192,8 +192,8 @@ test('Sprite dance changes will throw with invalid parameters', async t => {
     }
     nativeAPI.world.fullLengthMoveCount = moveCount;
     nativeAPI.world.restMoveCount = 1;
-  
-    const sprite = nativeAPI.makeNewDanceSprite("CAT", null, {x: 200, y: 200});  
+
+    const sprite = nativeAPI.makeNewDanceSprite("CAT", null, {x: 200, y: 200});
 
     testCode({ nativeAPI, sprite });
 
@@ -258,7 +258,7 @@ test('Sprite dance changes will allow short burst moves for doMoveLR but not cha
     nativeAPI.play({
       bpm: 120,
     });
-  
+
     // Mock cat animation poses
     for(let i = 0; i < moveCount; i++) {
       nativeAPI.setAnimationSpriteSheet("CAT", i, {}, () => {});
@@ -270,8 +270,8 @@ test('Sprite dance changes will allow short burst moves for doMoveLR but not cha
     }
     nativeAPI.world.fullLengthMoveCount = moveCount - shortMoveCount;
     nativeAPI.world.restMoveCount = 1;
-  
-    const sprite = nativeAPI.makeNewDanceSprite("CAT", null, {x: 200, y: 200});  
+
+    const sprite = nativeAPI.makeNewDanceSprite("CAT", null, {x: 200, y: 200});
 
     testCode({ nativeAPI, sprite });
 
@@ -388,6 +388,46 @@ test('setPropRandom set sprite y properties between 50 and 350', async t => {
   t.equal(sprite.y, 200);
   nativeAPI.setPropRandom(sprite, 'y');
   t.ok(sprite.y > 50 && sprite.y < 350);
+
+  t.end();
+
+  nativeAPI.reset();
+});
+
+test('startMapping/stopMapping adds and removes behaviors', async t => {
+  const nativeAPI = await helpers.createDanceAPI();
+  nativeAPI.play({
+    bpm: 120,
+  });
+  nativeAPI.setAnimationSpriteSheet("CAT", 0, {}, () => {});
+
+  const sprite = nativeAPI.makeNewDanceSprite("CAT", null, {x: 200, y: 200});
+
+  // This is 1 only because we have a behavior that we add to every sprite
+  // (which should arguably be a different concept)
+  t.equal(sprite.behaviors.length, 1);
+
+  nativeAPI.startMapping(sprite, 'x', 'bass');
+
+  t.equal(sprite.behaviors.length, 2);
+
+  // adding the same mapping again gets ignored
+  // TODO: this fails
+  // nativeAPI.startMapping(sprite, 'x', 'bass');
+  // t.equal(sprite.behaviors.length, 2);
+
+  // changing the range gives a new behavior
+  nativeAPI.startMapping(sprite, 'x', 'treble');
+  t.equal(sprite.behaviors.length, 3);
+
+  // changing the property gives a new behavior
+  nativeAPI.startMapping(sprite, 'y', 'bass');
+  t.equal(sprite.behaviors.length, 4);
+
+  // stop mapping removes behavior
+  nativeAPI.stopMapping(sprite, 'x', 'bass');
+  t.equal(sprite.behaviors.length, 3);
+
 
   t.end();
 

--- a/test/unit/spriteManipulation.js
+++ b/test/unit/spriteManipulation.js
@@ -412,9 +412,8 @@ test('startMapping/stopMapping adds and removes behaviors', async t => {
   t.equal(sprite.behaviors.length, 2);
 
   // adding the same mapping again gets ignored
-  // TODO: this fails
-  // nativeAPI.startMapping(sprite, 'x', 'bass');
-  // t.equal(sprite.behaviors.length, 2);
+  nativeAPI.startMapping(sprite, 'x', 'bass');
+  t.equal(sprite.behaviors.length, 2);
 
   // changing the range gives a new behavior
   nativeAPI.startMapping(sprite, 'x', 'treble');

--- a/test/unit/spriteManipulation.js
+++ b/test/unit/spriteManipulation.js
@@ -428,6 +428,9 @@ test('startMapping/stopMapping adds and removes behaviors', async t => {
   nativeAPI.stopMapping(sprite, 'x', 'bass');
   t.equal(sprite.behaviors.length, 3);
 
+  // removing a non-existent behavior is a noop
+  nativeAPI.stopMapping(sprite, 'rotation', 'bass');
+  t.equal(sprite.behaviors.length, 3);
 
   t.end();
 


### PR DESCRIPTION
Fix for https://github.com/code-dot-org/dance-party/issues/98

See https://github.com/code-dot-org/dance-party/pull/136 for analysis and a bigger fix we could take instead.

I think 136 + removal of the NoopBehavior hack mentioned there is the right long term fix for this bug. However, that's also a lot of change this short before HOC. This PR is a smaller scoped fix that I think is probably the right one to make short term.

Here we depend on coming up with an identifier per behavior that consists of the property we're wanting to modify and the energy range we want to track. Using this identifier we can then easily add/remove behaviors.

This is a reasonably good fix, but unlike #136 doesn't address the fact that we're using the Behavior concept for two reasonably different things.