### PR TITLE
Width height Prop fix

### DIFF
--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -104,6 +104,7 @@ module.exports = class DanceParty {
       p5Inst.preload = () => this.preload();
       p5Inst.setup = () => this.setup();
       p5Inst.draw = () => this.draw();
+      //Allows the sprite width and height to be set independently
       this.p5_._fixedSpriteAnimationFrameSizes = true;
     }, container);
   }

--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -104,6 +104,7 @@ module.exports = class DanceParty {
       p5Inst.preload = () => this.preload();
       p5Inst.setup = () => this.setup();
       p5Inst.draw = () => this.draw();
+      this.p5_._fixedSpriteAnimationFrameSizes = true;
     }, container);
   }
 

--- a/test/unit/spriteManipulation.js
+++ b/test/unit/spriteManipulation.js
@@ -385,3 +385,12 @@ test('setPropRandom set sprite y properties between 50 and 350', async t => {
 
   nativeAPI.reset();
 });
+
+test('p5 fixedSpriteAnimationSizes is true', async t => {
+  //Turning this flag on allows us to scale a sprite horizontally and vertically
+  const nativeAPI = await helpers.createDanceAPI();
+  t.ok(nativeAPI.p5_._fixedSpriteAnimationFrameSizes);
+  t.end();
+
+  nativeAPI.reset();
+});

--- a/test/unit/spriteManipulation.js
+++ b/test/unit/spriteManipulation.js
@@ -387,10 +387,39 @@ test('setPropRandom set sprite y properties between 50 and 350', async t => {
 });
 
 test('p5 fixedSpriteAnimationSizes is true', async t => {
-  //Turning this flag on allows us to scale a sprite horizontally and vertically
+  // Turning this flag on allows us to scale a sprite horizontally and vertically
   const nativeAPI = await helpers.createDanceAPI();
   t.ok(nativeAPI.p5_._fixedSpriteAnimationFrameSizes);
+  t.end();
+
+  nativeAPI.reset();
 });
+
+test('changing width and height accounted for during p5 draw', async t => {
+  const nativeAPI = await helpers.createDanceAPI();
+  nativeAPI.play({
+    bpm: 120,
+  });
+  nativeAPI.setAnimationSpriteSheet("CAT", 0, {}, () => {});
+
+  const sprite = nativeAPI.makeNewDanceSprite("CAT", null, {x: 200, y: 200});
+
+  // Initial value
+  t.equal(nativeAPI.p5_.allSprites.get(0)._getScaleX(), 1);
+  t.equal(nativeAPI.p5_.allSprites.get(0)._getScaleY(), 1);
+
+  nativeAPI.setProp(sprite, "width", 50);
+  nativeAPI.setProp(sprite, 'height', 75);
+
+  // setProp sets the value to SIZE (300) * (val / 100)
+  t.equal(nativeAPI.p5_.allSprites.get(0)._getScaleX(), 150);
+  t.equal(nativeAPI.p5_.allSprites.get(0)._getScaleY(), 225);
+
+  t.end();
+
+  nativeAPI.reset();
+});
+
 
 test('prev, next, and rand dance move will throw when not enough dance moves', async t => {
 


### PR DESCRIPTION
Addresses: https://github.com/code-dot-org/dance-party/issues/83

Similar to when we initialize p5 in Game Lab, turning on this sprite permits p5 to scale the sprite horizontally or vertically when the height and width are set. https://github.com/code-dot-org/p5.play/blob/4ae6d3dc336b2325fdb6d8816ee3f1ce95370d23/lib/p5.play.js#L1783

Includes test to make sure we don't remove the flag

Paired with @islemaster