### PR TITLE
After/Every N measures/seconds: generate events at proper times

### DIFF
--- a/levels/effectsLevels.js
+++ b/levels/effectsLevels.js
@@ -7,13 +7,13 @@ module.exports = {
       whenSetup(function () {
         setBackgroundEffect("color_cycle");
       });
-      
+
       atTimestamp(4, "measures", function () {
         setBackgroundEffect("text");
       });
     `,
     validationCode: `
-    
+
       if (nativeAPI.getTime("measures") > 1 && nativeAPI.getTime("measures") < 3) {
         if (World.bg_effect == null) {
           nativeAPI.fail("You need to add a background effect.");
@@ -21,15 +21,15 @@ module.exports = {
           nativeAPI.fail("You need to set the background to color_cycle");
         }
       }
-      
-      if (nativeAPI.getTime("measures") > 5) {
+
+      if (nativeAPI.getTime("measures") > 6) {
         if (World.bg_effect == null) {
           nativeAPI.fail("You need to add a background effect.");
         } else if (nativeAPI.getBackgroundEffect().texts == null) {
           nativeAPI.fail("You need to set the background to text");
         }
       }
-      
+
       if (nativeAPI.getTime("measures") > 7) {
         nativeAPI.pass();
       }

--- a/levels/hourOfCode.js
+++ b/levels/hourOfCode.js
@@ -41,7 +41,7 @@ module.exports = {
         }
       } else if (nativeAPI.getTime("measures") > 7) {
         nativeAPI.pass();
-      } else if (nativeAPI.getTime("measures") > 4.5) {
+      } else if (nativeAPI.getTime("measures") > 5.5) {
         if (sprites.length > 0) {
           if (sprites[0].current_move === World.startingMove) {
             nativeAPI.fail("Your dancer wasn't doing a new move after the fourth measure.");

--- a/levels/spriteDance.js
+++ b/levels/spriteDance.js
@@ -7,13 +7,14 @@ module.exports = {
       whenSetup(function () {
         lead_dancer = makeNewDanceSprite("CAT", lead_dancer, {x: 200, y: 200});
       });
-      
+
       everySeconds(2, "measures", function () {
         changeMoveLR(lead_dancer, 3, -1);
       });
-      
+
       everySeconds(4, "measures", function () {
         changeMoveLR(lead_dancer, 1, -1);
+        setProp(lead_dancer, "scale", 50);
       });
     `,
       `
@@ -22,26 +23,26 @@ module.exports = {
       whenSetup(function () {
         lead_dancer = makeNewDanceSprite("CAT", lead_dancer, {x: 200, y: 200});
       });
-      
+
       everySeconds(4, "measures", function () {
         changeMoveLR(lead_dancer, 1, -1);
       });
-      
+
       everySeconds(2, "measures", function () {
         changeMoveLR(lead_dancer, 3, -1);
       });
     `,
     ],
     validationCode: `
-      if (nativeAPI.getTime("measures") === 4) {
+      if (nativeAPI.getTime("measures") === 5) {
         let cats = nativeAPI.getGroupByName_('CAT');
         for(let i = 0; i < cats.length; i++){
           if(cats[i].current_move !== 1){
-            nativeAPI.fail("Cat sprite not dancing 1."); 
+            nativeAPI.fail("Cat sprite not dancing 1.");
           }
         }
       }
-      if (nativeAPI.getTime("measures") > 7 && nativeAPI.getTime("measures") < 8) {
+      if (nativeAPI.getTime("measures") > 8 && nativeAPI.getTime("measures") < 9) {
         let cats = nativeAPI.getGroupByName_('CAT');
         for(let i = 0; i < cats.length; i++){
           if(cats[i].current_move !== 3){
@@ -49,8 +50,16 @@ module.exports = {
           }
         }
       }
-      
-      if (nativeAPI.getTime("measures") > 8) {
+      if (nativeAPI.getTime("measures") > 1 && nativeAPI.getTime("measures") < 2) {
+        let cats = nativeAPI.getGroupByName_('CAT');
+        for(let i = 0; i < cats.length; i++){
+          if(nativeAPI.getProp(cats[i], "scale") === 50) {
+            nativeAPI.fail("Cat sprite event happened too early.");
+          }
+        }
+      }
+
+      if (nativeAPI.getTime("measures") > 9) {
         nativeAPI.pass();
       }
     `,
@@ -63,11 +72,11 @@ module.exports = {
       whenSetup(function () {
         lead_dancer = makeNewDanceSprite("CAT", lead_dancer, {x: 200, y: 200});
       });
-      
+
       everySeconds(3, "seconds", function () {
         changeMoveLR(lead_dancer, 3, -1);
       });
-      
+
       everySeconds(6, "seconds", function () {
         changeMoveLR(lead_dancer, 1, -1);
       });
@@ -78,11 +87,11 @@ module.exports = {
       whenSetup(function () {
         lead_dancer = makeNewDanceSprite("CAT", lead_dancer, {x: 200, y: 200});
       });
-      
+
       everySeconds(6, "seconds", function () {
         changeMoveLR(lead_dancer, 1, -1);
       });
-      
+
       everySeconds(3, "seconds", function () {
         changeMoveLR(lead_dancer, 3, -1);
       });
@@ -93,7 +102,7 @@ module.exports = {
         let cats = nativeAPI.getGroupByName_('CAT');
         for(let i = 0; i < cats.length; i++){
           if(cats[i].current_move !== 1){
-            nativeAPI.fail("Cat sprite not dancing 1."); 
+            nativeAPI.fail("Cat sprite not dancing 1.");
           }
         }
       }
@@ -101,11 +110,11 @@ module.exports = {
         let cats = nativeAPI.getGroupByName_('CAT');
         for(let i = 0; i < cats.length; i++){
           if(cats[i].current_move !== 3){
-            nativeAPI.fail("Cat sprite not dancing 3."); 
+            nativeAPI.fail("Cat sprite not dancing 3.");
           }
         }
       }
-      
+
       if (nativeAPI.getTime("seconds") > 9) {
         nativeAPI.pass();
       }
@@ -119,11 +128,11 @@ module.exports = {
       whenSetup(function () {
         lead_dancer = makeNewDanceSprite("CAT", lead_dancer, {x: 200, y: 200});
       });
-      
+
       everySeconds(2, "measures", function () {
         changeMoveLR(lead_dancer, 3, -1);
       });
-      
+
       atTimestamp(2, "measures", function () {
         changeMoveLR(lead_dancer, 1, -1);
       });
@@ -134,14 +143,14 @@ module.exports = {
       whenSetup(function () {
         lead_dancer = makeNewDanceSprite("CAT", lead_dancer, {x: 200, y: 200});
       });
-      
+
       atTimestamp(2, "measures", function () {
         changeMoveLR(lead_dancer, 1, -1);
       });
-      
+
       everySeconds(2, "measures", function () {
         changeMoveLR(lead_dancer, 3, -1);
-      });     
+      });
     `,
     ],
     validationCode: `
@@ -149,7 +158,7 @@ module.exports = {
         let cats = nativeAPI.getGroupByName_('CAT');
         for(let i = 0; i < cats.length; i++){
           if(cats[i].current_move !== 1){
-            nativeAPI.fail("Cat sprite not dancing 1."); 
+            nativeAPI.fail("Cat sprite not dancing 1.");
           }
         }
       }
@@ -157,11 +166,11 @@ module.exports = {
         let cats = nativeAPI.getGroupByName_('CAT');
         for(let i = 0; i < cats.length; i++){
           if(cats[i].current_move !== 3){
-            nativeAPI.fail("Cat sprite not dancing 3."); 
+            nativeAPI.fail("Cat sprite not dancing 3.");
           }
         }
       }
-      
+
       if (nativeAPI.getTime("measures") > 6) {
         nativeAPI.pass();
       }

--- a/src/p5.dance.interpreted.js
+++ b/src/p5.dance.interpreted.js
@@ -121,19 +121,26 @@ function atTimestamp(timestamp, unit, event) {
 }
 
 function everySeconds(n, unit, event) {
-  // TODO: 90 seconds is the max for songs, but 90 measures is too long
-  everySecondsRange(n, unit, 0, 90, event);
+  // Measures start counting at 1, whereas seconds start counting at 0.
+  // e.g. "every 4 measures" will generate events at "5, 9, 13" measures.
+  // e.g. "every 0.25 seconds" will generate events at "0.25, 0.5, 0.75" seconds.
+  var start, stop;
+  if (unit === "measures") {
+    start = 1;
+    // TODO: 90 seconds is the max for songs, but 90 measures is too long
+    stop = 91;
+  } else {
+    start = 0;
+    stop = 90;
+  }
+  everySecondsRange(n, unit, start, stop, event);
 }
 
 function everySecondsRange(n, unit, start, stop, event) {
   if (n > 0) {
-    // There are two offsets involved in the initial timestamp.
     // Offset by n so that we don't generate an event at the beginning
     // of the first period.
-    // And, if "measures", offset by 1, since they start at 1.
-    // e.g. "every 4 measures" will generate events at "5, 9, 13" measures.
-    // e.g. "every 0.25 seconds" will generate events at "0.25, 0.5, 0.75" seconds.
-    var timestamp = start + n + (unit === "measures" ? 1 : 0);
+    var timestamp = start + n;
 
     while (timestamp < stop) {
       inputEvents.push({

--- a/src/p5.dance.interpreted.js
+++ b/src/p5.dance.interpreted.js
@@ -110,6 +110,10 @@ function whenPeak(range, event) {
 }
 
 function atTimestamp(timestamp, unit, event) {
+  if (unit === "measures") {
+    timestamp += 1;
+  }
+
   // Increment priority by 1 to account for 'atTimestamp' events having a higher priority
   // than everySecond events when they have share a timestamp parameter
   inputEvents.push({

--- a/src/p5.dance.interpreted.js
+++ b/src/p5.dance.interpreted.js
@@ -127,7 +127,13 @@ function everySeconds(n, unit, event) {
 
 function everySecondsRange(n, unit, start, stop, event) {
   if (n > 0) {
-    var timestamp = start;
+    // There are two offsets involved in the initial timestamp.
+    // Offset by n so that we don't generate an event at the beginning
+    // of the first period.  And if "measures", offset by 1, since we
+    // want to generate the event at the beginning of the next measure.
+    // e.g. "every 4 measures" will generate events at "5, 9, 13" measures.
+    var timestamp = start + n + (unit === "measures" ? 1 : 0);
+
     while (timestamp < stop) {
       inputEvents.push({
         type: 'cue-' + unit,

--- a/src/p5.dance.interpreted.js
+++ b/src/p5.dance.interpreted.js
@@ -128,7 +128,7 @@ function everySeconds(n, unit, event) {
 function everySecondsRange(n, unit, start, stop, event) {
   if (n > 0) {
     // There are two offsets involved in the initial timestamp.
-    // Offset by n so that we don't generate an event before the beginning
+    // Offset by n so that we don't generate an event at the beginning
     // of the first duration.  And offset by 1, since we want to generate the
     // event at the beginning of the next measure or second.
     // e.g. "every 4 measures" will generate events at "5, 9, 13" measures.

--- a/src/p5.dance.interpreted.js
+++ b/src/p5.dance.interpreted.js
@@ -128,11 +128,11 @@ function everySeconds(n, unit, event) {
 function everySecondsRange(n, unit, start, stop, event) {
   if (n > 0) {
     // There are two offsets involved in the initial timestamp.
-    // Offset by n so that we don't generate an event at the beginning
-    // of the first period.  And if "measures", offset by 1, since we
-    // want to generate the event at the beginning of the next measure.
+    // Offset by n so that we don't generate an event before the beginning
+    // of the first duration.  And offset by 1, since we want to generate the
+    // event at the beginning of the next measure or second.
     // e.g. "every 4 measures" will generate events at "5, 9, 13" measures.
-    var timestamp = start + n + (unit === "measures" ? 1 : 0);
+    var timestamp = start + n + 1;
 
     while (timestamp < stop) {
       inputEvents.push({

--- a/src/p5.dance.interpreted.js
+++ b/src/p5.dance.interpreted.js
@@ -129,10 +129,11 @@ function everySecondsRange(n, unit, start, stop, event) {
   if (n > 0) {
     // There are two offsets involved in the initial timestamp.
     // Offset by n so that we don't generate an event at the beginning
-    // of the first duration.  And offset by 1, since we want to generate the
-    // event at the beginning of the next measure or second.
+    // of the first period.
+    // And, if "measures", offset by 1, since they start at 1.
     // e.g. "every 4 measures" will generate events at "5, 9, 13" measures.
-    var timestamp = start + n + 1;
+    // e.g. "every 0.25 seconds" will generate events at "0.25, 0.5, 0.75" seconds.
+    var timestamp = start + n + (unit === "measures" ? 1 : 0);
 
     while (timestamp < stop) {
       inputEvents.push({


### PR DESCRIPTION
Previously, `"Every 4 measures"` was generating events at the beginning of measures `1, 4, 8, 12`.   Now, they're at the beginning of measures `5, 9, 13`.

`"Every 4 seconds"` was generating events at the beginning of seconds `0, 4, 8, 12`.  Now they're at the beginning of seconds `4, 8, 12`.

Fractional values should also work.  `"Every 0.25 measures"` will be `1.25, 1.5, 1.75`.  `"Every 0.25 seconds"` will be `0.25, 1.5, 1.75`.

Finally, the "After 4 measures" event (which uses the deceptively-named `atTimestamp` function) was generating an event at the beginning of measure 4.  Now it's at the beginning of measure 5.

Fixes #51 