### PR TITLE
update playSound args in demo

### DIFF
--- a/demo.js
+++ b/demo.js
@@ -3,7 +3,9 @@ import jazzy_beats from './metadata/jazzy_beats';
 
 const nativeAPI = window.nativeAPI = new DanceParty({
   onPuzzleComplete: () => {},
-  playSound: ({callback}) => setTimeout(() => {callback && callback();}, 0),
+  playSound: (url, callback, onEnded) => setTimeout(() => {
+    callback && callback();
+  }, 0),
   onInit: () => {
     // Sample user code:
     nativeAPI.setBackgroundEffect('disco');


### PR DESCRIPTION
We changed the args passed to playSound, and need to update our demo env appropriately.

Before this change, the measure count in the top right was not updating.