### PR TITLE
Safe to call commands with empty group names

### DIFF
--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -283,10 +283,7 @@ module.exports = class DanceParty {
     var sprite = this.p5_.createSprite(location.x, location.y);
 
     sprite.style = costume;
-    if (!this.sprites_by_type_.hasOwnProperty(costume)) {
-      this.sprites_by_type_[costume] = this.p5_.createGroup();
-    }
-    this.sprites_by_type_[costume].add(sprite);
+    this.getGroupByName_(costume).add(sprite);
 
     sprite.mirroring = 1;
     sprite.looping_move = 0;
@@ -464,14 +461,14 @@ module.exports = class DanceParty {
     if (typeof(group) === "object") {
       return group;
     }
-    if (group !== "all") {
-      if (!this.sprites_by_type_.hasOwnProperty(group)) {
-        console.log("There is no group of " + group);
-        return;
-      }
-      return this.sprites_by_type_[group];
+    if (group === "all") {
+      return this.p5_.allSprites;
     }
-    return this.p5_.allSprites;
+
+    if (!this.sprites_by_type_.hasOwnProperty(group)) {
+      this.sprites_by_type_[group] = this.p5_.createGroup();
+    }
+    return this.sprites_by_type_[group];
   }
 
   changeMoveEachLR(group, move, dir) {

--- a/test/unit/groupTest.js
+++ b/test/unit/groupTest.js
@@ -32,6 +32,24 @@ test('changing dance moves for all updates all dancers', async t => {
   nativeAPI.reset();
 });
 
+test('changing dance moves for empty group does nothing without error', async t => {
+  const nativeAPI = await helpers.createDanceAPI();
+  nativeAPI.play({
+    bpm: 120,
+  });
+
+  nativeAPI.setAnimationSpriteSheet("CAT", 0, {}, () => {});
+  const catSprite = nativeAPI.makeNewDanceSprite("CAT", null, {x: 200, y: 200});
+
+  t.equal(catSprite.current_move, 0);
+  nativeAPI.changeMoveEachLR('BEAR', 1);
+  t.equal(catSprite.current_move, 0);
+
+  t.end();
+
+  nativeAPI.reset();
+});
+
 test('changing visibility for all updates all dancers', async t => {
   const nativeAPI = await helpers.createDanceAPI();
   nativeAPI.play({
@@ -149,7 +167,7 @@ test('GetGroupByName returns the expected number of sprites ', async t => {
   t.equal(nativeAPI.getGroupByName_('all').length, 4);
   t.equal(nativeAPI.getGroupByName_('CAT').length, 2);
   t.equal(nativeAPI.getGroupByName_('ALIEN').length, 1);
-  t.equal(nativeAPI.getGroupByName_('DOG'), undefined);
+  t.equal(nativeAPI.getGroupByName_('DOG').length, 0);
 
   t.end();
 
@@ -184,6 +202,22 @@ test('LayoutSprites sets the x position of sprites in the expected orientation',
   for (let i = 0; i < cats.length; i++) {
     t.equal(cats[i].x, 200);
   }
+
+  t.end();
+
+  nativeAPI.reset();
+});
+
+test('LayoutSprites is safe to call with any layout on an empty group', async t => {
+  // Checking for divide-by-zero errors
+  const nativeAPI = await helpers.createDanceAPI();
+  nativeAPI.play({
+    bpm: 120,
+  });
+
+  ['circle', 'plus', 'x', 'grid', 'inner', 'row', 'column', 'border', 'random'].forEach(layout => {
+    nativeAPI.layoutSprites('BEAR', layout);
+  });
 
   t.end();
 


### PR DESCRIPTION
Fixes #168 

Retrieving a sprite group by name that doesn't exist yet now creates and returns the empty group, which should resolve this issue for all group commands.

Made sure to add testing for sprite layouts in case there were surprise divide-by-zero issues after this change.