### PR TITLE
fix sorting of move names

### DIFF
--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -92,7 +92,7 @@ module.exports = class DanceParty {
     // Sort after spriteConfig function has executed to ensure that
     // rest moves are at the beginning and shortBurst moves are all at the end
     this.world.MOVE_NAMES = this.world.MOVE_NAMES.sort((move1, move2) => (
-      !!move1.rest * -2 * !!move2.rest * 2 + !!move2.shortBurst * -1 + !!move1.shortBurst * 1
+      !!move1.rest * -2 + !!move2.rest * 2 + !!move2.shortBurst * -1 + !!move1.shortBurst * 1
     ));
     this.world.restMoveCount = this.world.MOVE_NAMES.filter(move => move.rest).length;
     this.world.fullLengthMoveCount = this.world.MOVE_NAMES.filter(move => !move.shortBurst).length;

--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -92,7 +92,7 @@ module.exports = class DanceParty {
     // Sort after spriteConfig function has executed to ensure that
     // rest moves are at the beginning and shortBurst moves are all at the end
     this.world.MOVE_NAMES = this.world.MOVE_NAMES.sort((move1, move2) => (
-      move1.rest * -2 * move2.rest * 2 + move2.shortBurst * -1 + move1.shortBurst * 1
+      !!move1.rest * -2 * !!move2.rest * 2 + !!move2.shortBurst * -1 + !!move1.shortBurst * 1
     ));
     this.world.restMoveCount = this.world.MOVE_NAMES.filter(move => move.rest).length;
     this.world.fullLengthMoveCount = this.world.MOVE_NAMES.filter(move => !move.shortBurst).length;

--- a/test/unit/spriteManipulation.js
+++ b/test/unit/spriteManipulation.js
@@ -251,6 +251,55 @@ test('Sprite dance changes will throw with invalid parameters', async t => {
   t.end();
 });
 
+test('Sprite move sorting works reliably', async t => {
+  const moveNames = [
+    {
+      name: 'rest',
+      rest: true,
+    },
+    {
+      name: 'fullLength1',
+    },
+    {
+      name: 'fullLength2',
+    },
+    {
+      name: 'shortBurst1',
+      shortBurst: true,
+    },
+    {
+      name: 'shortBurst2',
+      shortBurst: true,
+    },
+  ];
+
+  const P5 = require('../../src/loadP5');
+
+  P5.prototype.loadJSON = function (_url, callback) {
+    setTimeout(() => {
+      this._preloadCount--;
+      this._runIfPreloadsAreDone();
+      callback('{"frames":{}}');  
+    }, 0);
+  }
+  P5.prototype.loadImageElement = function(_url, callback) {
+    setTimeout(() => {
+      this._preloadCount--;
+      this._runIfPreloadsAreDone();
+      callback(new Image());
+    }, 0);
+  }
+
+  const nativeAPI = await helpers.createDanceAPI({ moveNames, spriteConfig: world => { world.SPRITE_NAMES = ['foo']; } });
+
+  nativeAPI.p5_.noLoop();
+
+  // The MOVE_NAMES as provided have not been changed.
+  t.deepEqual(nativeAPI.world.MOVE_NAMES, moveNames);
+
+  t.end();
+});
+
 test('Sprite dance changes will allow short burst moves for doMoveLR but not changeMoveLR', async t => {
 
   const subTest = async ({ moveCount = 3, shortMoveCount = 1, testCode }) => {

--- a/test/unit/spriteManipulation.js
+++ b/test/unit/spriteManipulation.js
@@ -279,16 +279,16 @@ test('Sprite move sorting works reliably', async t => {
     setTimeout(() => {
       this._preloadCount--;
       this._runIfPreloadsAreDone();
-      callback('{"frames":{}}');  
+      callback('{"frames":{}}');
     }, 0);
-  }
-  P5.prototype.loadImageElement = function(_url, callback) {
+  };
+  P5.prototype.loadImageElement = function (_url, callback) {
     setTimeout(() => {
       this._preloadCount--;
       this._runIfPreloadsAreDone();
       callback(new Image());
     }, 0);
-  }
+  };
 
   const nativeAPI = await helpers.createDanceAPI({ moveNames, spriteConfig: world => { world.SPRITE_NAMES = ['foo']; } });
 


### PR DESCRIPTION
* Sorting of `MOVE_NAMES` was broken (references to `undefined` properties behave differently than `false` properties)
* Added test case to verify sorting. This one was a little tricky as it is our first test case that runs all of the init code (loading JSON, spritesheets, etc.). I tried to stub out `XMLHttpRequest` with sinon, but that proved to be quite complex in our current harness environment. For now, I've done a simpler change which is to stub out `p5`'s `loadJSON()` and `loadImageElement()` - which allows us to run through the `DanceParty` constructor properly with `MOVE_NAMES` and `SPRITE_NAMES` preset.