### PR TITLE
Add frameRate to test interface for stress testing

### DIFF
--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -129,6 +129,7 @@ module.exports = class DanceParty {
       getSprites: () => this.p5_ && this.p5_.allSprites,
       getSongUrl: () => this.songMetadata_ && this.songMetadata_.file,
       getSongStartedTime: () => this.songStartTime_,
+      frameRate: () => this.p5_.frameRate(),
     };
   }
 


### PR DESCRIPTION
I'd like to monitor and report framerate from our stress tests but can't get to p5 right now.  Exposing this in the test interface (which in turn gets exposed on window) so we can check it during stress tests.