### PR TITLE
Instrument client timing metrics

### DIFF
--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -84,9 +84,9 @@ module.exports = class DanceParty {
     this.performanceData_ = {
       // Time from the start of document load to the init() callback
       initTime: null,
-      // Time the run button was last clicked
+      // Time play() was last called
       lastPlayCall: null,
-      // Time between last run click and last time the song actually started playing
+      // Time between last play() call and last time the song actually started playing
       lastPlayDelay: null,
       // Number of frame rate samples taken since last run
       frameRateSamples: 0,
@@ -147,7 +147,7 @@ module.exports = class DanceParty {
       getSprites: () => this.p5_ && this.p5_.allSprites,
       getSongUrl: () => this.songMetadata_ && this.songMetadata_.file,
       getSongStartedTime: () => this.songStartTime_,
-      getPerformanceData: () => JSON.parse(JSON.stringify(this.performanceData_)),
+      getPerformanceData: () => Object.assign({}, this.performanceData_),
     };
   }
 
@@ -1063,5 +1063,5 @@ function timeSinceLoad() {
   } else if (typeof process !== 'undefined') {
     return process.hrtime();
   }
-  return Date.now();
+  return 0;
 }

--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -238,7 +238,7 @@ module.exports = class DanceParty {
       }
     }
 
-    this.performanceData_.initTime = performance.now();
+    this.performanceData_.initTime = timeSinceLoad();
     this.onInit && this.onInit(this);
   }
 
@@ -261,7 +261,7 @@ module.exports = class DanceParty {
     this.analysisPosition_ = 0;
     this.playSound_(this.songMetadata_.file, playSuccess => {
       this.songStartTime_ = new Date();
-      this.performanceData_.lastPlayDelay = performance.now() - this.performanceData_.lastPlayCall;
+      this.performanceData_.lastPlayDelay = timeSinceLoad() - this.performanceData_.lastPlayCall;
       callback && callback(playSuccess);
     }, () => {
       this.reset();
@@ -959,7 +959,7 @@ module.exports = class DanceParty {
   }
 
   resetPerformanceDataForRun_() {
-    this.performanceData_.lastPlayCall = performance.now();
+    this.performanceData_.lastPlayCall = timeSinceLoad();
     this.performanceData_.lastPlayDelay = null;
     this.performanceData_.frameRateSamples = 0;
     this.performanceData_.frameRateMax = -Infinity;
@@ -1055,4 +1055,13 @@ function queryParam(key) {
     return decodeURIComponent(pair[1]);
   }
   return undefined;
+}
+
+function timeSinceLoad() {
+  if (typeof performance !== 'undefined') {
+    return performance.now()
+  } else if (typeof process !== 'undefined') {
+    return process.hrtime();
+  }
+  return Date.now();
 }


### PR DESCRIPTION
Record some load time and performance metrics that we can read from our stress testing system.

We're sampling frame rate and updating max/min/mean at a rate of once every 15 frames.  I was extra paranoid and did some local profiling to check if this was having any impact on the overall performance of the client - it's very lightweight, and now showing up in the profiler at all.

Extended with code-studio-side metrics in https://github.com/code-dot-org/code-dot-org/pull/25941. See also https://github.com/code-dot-org/dance-stress-test/blob/a36eb27aba97e3df12af2a7e5af6037f377c2ee2/tests/DancePage.py#L120-L139.