### PR TITLE
Fix move sorting again

### DIFF
--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -110,7 +110,7 @@ module.exports = class DanceParty {
 
     // We can't use Array.sort() : see https://stackoverflow.com/q/3026281
     const restMoves = this.world.MOVE_NAMES.filter(move => move.rest);
-    const nonRestingFullLengthMoves = this.world.MOVE_NAMES.filter(move => !move.rest & !move.shortBurst);
+    const nonRestingFullLengthMoves = this.world.MOVE_NAMES.filter(move => !move.rest && !move.shortBurst);
     const shortBurstMoves = this.world.MOVE_NAMES.filter(move => move.shortBurst);
     this.world.MOVE_NAMES = [
       ...restMoves,

--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -107,11 +107,18 @@ module.exports = class DanceParty {
 
     // Sort after spriteConfig function has executed to ensure that
     // rest moves are at the beginning and shortBurst moves are all at the end
-    this.world.MOVE_NAMES = this.world.MOVE_NAMES.sort((move1, move2) => (
-      !!move1.rest * -2 + !!move2.rest * 2 + !!move2.shortBurst * -1 + !!move1.shortBurst * 1
-    ));
-    this.world.restMoveCount = this.world.MOVE_NAMES.filter(move => move.rest).length;
-    this.world.fullLengthMoveCount = this.world.MOVE_NAMES.filter(move => !move.shortBurst).length;
+
+    // We can't use Array.sort() : see https://stackoverflow.com/q/3026281
+    const restMoves = this.world.MOVE_NAMES.filter(move => move.rest);
+    const nonRestingFullLengthMoves = this.world.MOVE_NAMES.filter(move => !move.rest & !move.shortBurst);
+    const shortBurstMoves = this.world.MOVE_NAMES.filter(move => move.shortBurst);
+    this.world.MOVE_NAMES = [
+      ...restMoves,
+      ...nonRestingFullLengthMoves,
+      ...shortBurstMoves,
+    ];
+    this.world.restMoveCount = restMoves.length;
+    this.world.fullLengthMoveCount = restMoves.length + shortBurstMoves.length;
 
     this.songStartTime_ = 0;
 

--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -118,7 +118,7 @@ module.exports = class DanceParty {
       ...shortBurstMoves,
     ];
     this.world.restMoveCount = restMoves.length;
-    this.world.fullLengthMoveCount = restMoves.length + shortBurstMoves.length;
+    this.world.fullLengthMoveCount = restMoves.length + nonRestingFullLengthMoves.length;
 
     this.songStartTime_ = 0;
 


### PR DESCRIPTION
* Even though we just fixed this sorting algorithm and added test cases, we were still susceptible to `Array.sort()` not being stable: see https://stackoverflow.com/q/3026281 (in particular Chrome <= 69 was unstable with arrays of more than 10 elements)
* Fixed by using 3 calls to `Array.filter()` which does preserve order: see https://stackoverflow.com/a/39712200
