### PR TITLE
Only publish required files

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "0.0.28",
   "description": "",
   "main": "dist/main.js",
+  "files": [
+    "dist/main.js",
+    "src/*.interpreted.js"
+  ],
   "scripts": {
     "build": "webpack -p",
     "dev": "webpack-dev-server --mode development",


### PR DESCRIPTION
Limits the files we publish to npm to `dist/main.json` and `src/p5.dance.interpreted.js`.

I noticed publishing a new version this morning that the published package was very large, probably since we have assets checked in to this repo now.

```
╰○ npm publish --dry-run
npm notice 
npm notice 📦  @code-dot-org/dance-party@0.0.29
npm notice === Tarball Contents === 
npm notice 1.8kB   package.json                          
npm notice 25B     .babelrc                              
npm notice 1.6kB   .eslintrc.js                          
npm notice 7B      .nvmrc                                
npm notice 445B    .travis.yml                           
npm notice 1.4kB   demo.js                               
npm notice 393B    index.html                            
npm notice 1.1kB   karma.conf.js                         
npm notice 1.2kB   README.md                             
npm notice 292B    webpack.config.js                     
npm notice 1.1kB   assets/create_sprite_sheets.sh        
npm notice 243.9kB assets/sprite_sheets/alien_00.png     
npm notice 243.8kB assets/sprite_sheets/alien_01.png     
npm notice 266.9kB assets/sprite_sheets/alien_02.png     
npm notice 256.3kB assets/sprite_sheets/alien_03.png     
npm notice 233.0kB assets/sprite_sheets/bear_04.png      
npm notice 204.8kB assets/sprite_sheets/bear_05.png      
npm notice 214.3kB assets/sprite_sheets/bear_06.png      
npm notice 234.2kB assets/sprite_sheets/bear_07.png      
npm notice 306.1kB assets/sprite_sheets/cat_08.png       
npm notice 282.4kB assets/sprite_sheets/cat_09.png       
npm notice 283.0kB assets/sprite_sheets/cat_10.png       
npm notice 309.0kB assets/sprite_sheets/cat_11.png       
npm notice 647.3kB assets/sprite_sheets/characters.json  
npm notice 230.1kB assets/sprite_sheets/dog_12.png       
npm notice 224.1kB assets/sprite_sheets/dog_13.png       
npm notice 242.8kB assets/sprite_sheets/dog_14.png       
npm notice 250.2kB assets/sprite_sheets/dog_15.png       
npm notice 221.0kB assets/sprite_sheets/duck_16.png      
npm notice 202.5kB assets/sprite_sheets/duck_17.png      
npm notice 211.0kB assets/sprite_sheets/duck_18.png      
npm notice 245.7kB assets/sprite_sheets/duck_19.png      
npm notice 226.9kB assets/sprite_sheets/frog_20.png      
npm notice 215.0kB assets/sprite_sheets/frog_21.png      
npm notice 235.5kB assets/sprite_sheets/frog_22.png      
npm notice 242.0kB assets/sprite_sheets/frog_23.png      
npm notice 260.0kB assets/sprite_sheets/moose_24.png     
npm notice 214.3kB assets/sprite_sheets/moose_25.png     
npm notice 249.7kB assets/sprite_sheets/moose_26.png     
npm notice 268.7kB assets/sprite_sheets/moose_27.png     
npm notice 284.6kB assets/sprite_sheets/pineapple_28.png 
npm notice 271.0kB assets/sprite_sheets/pineapple_29.png 
npm notice 273.4kB assets/sprite_sheets/pineapple_30.png 
npm notice 310.1kB assets/sprite_sheets/pineapple_31.png 
npm notice 277.1kB assets/sprite_sheets/robot_32.png     
npm notice 260.5kB assets/sprite_sheets/robot_33.png     
npm notice 258.2kB assets/sprite_sheets/robot_34.png     
npm notice 288.4kB assets/sprite_sheets/robot_35.png     
npm notice 213.1kB assets/sprite_sheets/shark_36.png     
npm notice 187.6kB assets/sprite_sheets/shark_37.png     
npm notice 214.1kB assets/sprite_sheets/shark_38.png     
npm notice 235.5kB assets/sprite_sheets/shark_39.png     
npm notice 262.0kB assets/sprite_sheets/unicorn_40.png   
npm notice 243.3kB assets/sprite_sheets/unicorn_41.png   
npm notice 252.5kB assets/sprite_sheets/unicorn_42.png   
npm notice 275.5kB assets/sprite_sheets/unicorn_43.png   
npm notice 4.1MB   dist/demo.js                          
npm notice 3.0MB   dist/main.js                          
npm notice 1.1kB   levels/effectsLevels.js               
npm notice 4.8kB   levels/hourOfCode.js                  
npm notice 4.9kB   levels/spriteDance.js                 
npm notice 399.2kB metadata/hammer.json                  
npm notice 721.5kB metadata/jazzy_beats.json             
npm notice 686.4kB metadata/macklemore90.json            
npm notice 647.2kB metadata/peas.json                    
npm notice 3.2kB   src/api.js                            
npm notice 1.4kB   src/constants.js                      
npm notice 19.6kB  src/Effects.js                        
npm notice 183B    src/index.js                          
npm notice 457B    src/loadP5.js                         
npm notice 3.6kB   src/modifySongData.js                 
npm notice 6.5kB   src/p5.dance.interpreted.js           
npm notice 32.7kB  src/p5.dance.js                       
npm notice 1.7kB   src/replay.js                         
npm notice 1.3kB   src/ResourceLoader.js                 
npm notice 424B    test/helpers/createDanceAPI.js        
npm notice 1.3kB   test/helpers/injectInterpreted.js     
npm notice 1.1kB   test/helpers/runLevel.js              
npm notice 755B    test/helpers/UnitTestResourceLoader.js
npm notice 347B    test/integration/effectsLevelTest.js  
npm notice 2.7kB   test/integration/hourOfCodeTest.js    
npm notice 90B     test/integration/index.js             
npm notice 1.5kB   test/integration/spriteDanceTest.js   
npm notice 961B    test/unit/cuesTest.js                 
npm notice 1.2kB   test/unit/effects.js                  
npm notice 3.2kB   test/unit/effectsTest.js              
npm notice 4.3kB   test/unit/eventsTest.js               
npm notice 7.4kB   test/unit/groupTest.js                
npm notice 10.9kB  test/unit/layoutTest.js               
npm notice 1.4kB   test/unit/measureCounterTest.js       
npm notice 1.0kB   test/unit/modifySongDataTest.js       
npm notice 593B    test/unit/replayTest.js               
npm notice 881B    test/unit/sanity.js                   
npm notice 17.5kB  test/unit/spriteManipulation.js       
npm notice 654B    test/unit/testInterfaceTest.js        
npm notice 769B    test/unit/whenKeyTest.js              
npm notice === Tarball Details === 
npm notice name:          @code-dot-org/dance-party               
npm notice version:       0.0.29                                  
npm notice package size:  13.1 MB                                 
npm notice unpacked size: 21.3 MB                                 
npm notice shasum:        cfb2e25d5a4992714956f549921fa43635863d57
npm notice integrity:     sha512-6HZ25sLAtqMwa[...]okmX3rtK62HIg==
npm notice total files:   96                                      
npm notice 
+ @code-dot-org/dance-party@0.0.29
```

We only use the built `dist/main.js` and the `p5.dance.interpreted.js` file from our main repo, so let's only publish those!

```
╰○ npm publish --dry-run
npm notice 
npm notice 📦  @code-dot-org/dance-party@0.0.29
npm notice === Tarball Contents === 
npm notice 1.8kB package.json               
npm notice 1.2kB README.md                  
npm notice 3.0MB dist/main.js               
npm notice 6.5kB src/p5.dance.interpreted.js
npm notice === Tarball Details === 
npm notice name:          @code-dot-org/dance-party               
npm notice version:       0.0.29                                  
npm notice package size:  746.0 kB                                
npm notice unpacked size: 3.0 MB                                  
npm notice shasum:        def26f371d9811b5ce59669f8f05ae2b211f5419
npm notice integrity:     sha512-KOoMqHAmLqxw5[...]3JZi4hf87cM6Q==
npm notice total files:   4                                       
npm notice 
+ @code-dot-org/dance-party@0.0.29
```

_Warning:_ The `--dry-run` option to npm publish doesn't exist in npm 3.10 (node 6), but does exist in npm 6.4 (node 8).  If you forget to `nvm use` it's easy to accidentally publish a version - I did this morning and had to immediately unpublish, which fortunately they still allow you to do!