### PR TITLE
Maximum event rate

### DIFF
--- a/src/p5.dance.interpreted.js
+++ b/src/p5.dance.interpreted.js
@@ -228,6 +228,20 @@ function everySecondsRange(n, unit, start, stop, func) {
     return;
   }
 
+  // Limit minimum event interval to avoid performance problems
+  // from student code like `every 0.001 seconds do...`
+  if ('seconds' === unit) {
+    // Maximum of 10 events per second
+    // Our fastest song is 169bpm
+    // This allows events on eighth-notes in that song.
+    n = Math.max(0.1, n);
+  } else {
+    // Maximum of ten events per measure
+    // Our fastest song is 169bpm
+    // This allows events every 142ms in that song
+    n = Math.max(0.1, n);
+  }
+
   // Offset by n so that we don't generate an event at the beginning
   // of the first period.
   var timestamp = start + n;

--- a/test/unit/eventsTest.js
+++ b/test/unit/eventsTest.js
@@ -142,3 +142,41 @@ test('non-conflicting atTimestamp cues, both take effect', async t => {
   t.end();
   nativeAPI.reset();
 });
+
+test('silently clamp maximum event rate in seconds', async t => {
+  // Try and create an event that's waaay too frequent
+  const {nativeAPI, interpretedAPI} = await runUserCode(`
+    everySeconds(0.00314, "seconds", function () {});
+  `);
+
+  const assertClose = (a, b) => t.ok(Math.abs(a - b) < 1.0e-7, `${a} and ${b} were within 1.0e-7`);
+  const cueList = interpretedAPI.getCueList();
+  assertClose(cueList.seconds[0], 0.1);
+  assertClose(cueList.seconds[1], 0.2);
+  assertClose(cueList.seconds[2], 0.3);
+  assertClose(cueList.seconds[3], 0.4);
+  assertClose(cueList.seconds[4], 0.5);
+  assertClose(cueList.seconds[5], 0.6);
+
+  t.end();
+  nativeAPI.reset();
+});
+
+test('silently clamp maximum event rate in measures', async t => {
+  // Try and create an event that's waaay too frequent
+  const {nativeAPI, interpretedAPI} = await runUserCode(`
+    everySeconds(0.00314, "measures", function () {});
+  `);
+
+  const assertClose = (a, b) => t.ok(Math.abs(a - b) < 1e-7, `${a} and ${b} were within 1e-7`);
+  const cueList = interpretedAPI.getCueList();
+  assertClose(cueList.measures[0], 1.1);
+  assertClose(cueList.measures[1], 1.2);
+  assertClose(cueList.measures[2], 1.3);
+  assertClose(cueList.measures[3], 1.4);
+  assertClose(cueList.measures[4], 1.5);
+  assertClose(cueList.measures[5], 1.6);
+
+  t.end();
+  nativeAPI.reset();
+});


### PR DESCRIPTION
Partial fix for https://github.com/code-dot-org/dance-party/issues/321

Ensures we don't fire events more than once every 100ms when a student writes code like `every 0.001 measures` or `every 0.001 seconds`.

@ryansloan requested a limit of 0.1 for both seconds and measures, which effectively limits us to events on eighth notes on our fastest song at 169bpm.

The other half of this work will happen in the code-dot-org repo, enforcing the limit at the block UI layer.