### PR TITLE
add bubbles foreground to dance party

### DIFF
--- a/src/Effects.js
+++ b/src/Effects.js
@@ -600,6 +600,36 @@ module.exports = class Effects {
         });
       }
     };
+
+    this.bubbles = {
+      bubble: [],
+      draw: function () {
+        let bubble = {
+          x: p5.random(-100, 400),
+          y: 410,
+          velocityX: p5.random(-2, 2),
+          size: p5.random(6, 12, 18),
+          color: randomColor(100, 50, 0.25),
+        };
+        this.bubble.push(bubble);
+        p5.noStroke();
+        this.bubble.forEach(function (bubble) {
+          p5.push();
+          p5.fill(bubble.color);
+          p5.translate(bubble.x, bubble.y);
+          for (let i = 0; i < 1; i++) {
+            p5.ellipse(0, 0, bubble.size, bubble.size);
+          }
+          let fallSpeed = p5.map(bubble.size, 6, 12, 1, 3);
+          bubble.y -= fallSpeed;
+          bubble.x += bubble.velocityX;
+          p5.pop();
+        });
+        this.bubble = this.bubble.filter(function (bubble) {
+          return bubble.y > 0;
+        });
+      }
+    };
   }
 };
 


### PR DESCRIPTION
add bubbles foreground to dance party. can update color scheme based on feedback.

![bubbles](https://user-images.githubusercontent.com/8651388/48670078-42cdae00-eac6-11e8-9ac7-53af17105702.gif)
