### PR TITLE
Layouts: reset all rotations for border layout

### DIFF
--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -634,18 +634,22 @@ module.exports = class DanceParty {
       if (count > 0) {
         group[0].x = minX;
         group[0].y = minY;
+        group[0].rotation = 0;
       }
       if (count > 1) {
         group[1].x = maxX;
         group[1].y = minY;
+        group[1].rotation = 0;
       }
       if (count > 2) {
         group[2].x = maxX;
         group[2].y = maxY;
+        group[2].rotation = 0;
       }
       if (count > 3) {
         group[3].x = minX;
         group[3].y = maxY;
+        group[3].rotation = 0;
       }
       if (count > 4) {
         const topCount = Math.ceil((count - 4 - 0) / 4);

--- a/test/unit/groupTest.js
+++ b/test/unit/groupTest.js
@@ -251,10 +251,16 @@ test('LayoutSprites resets rotation', async t => {
   });
   nativeAPI.setAnimationSpriteSheet("CAT", 0, {}, () => {});
   nativeAPI.makeNewDanceSpriteGroup(3, 'CAT', 'circle');
-  nativeAPI.layoutSprites('CAT', 'circle');
-  nativeAPI.layoutSprites('CAT', 'grid');
 
+  nativeAPI.layoutSprites('CAT', 'grid');
   let cats = nativeAPI.getGroupByName_('CAT');
+  for (let i = 0; i < cats.length; i++) {
+    t.equal(cats[i].rotation, 0);
+  }
+
+  nativeAPI.layoutSprites('CAT', 'circle');
+  nativeAPI.layoutSprites('CAT', 'border');
+  cats = nativeAPI.getGroupByName_('CAT');
   for (let i = 0; i < cats.length; i++) {
     t.equal(cats[i].rotation, 0);
   }


### PR DESCRIPTION
The prior work in https://github.com/code-dot-org/dance-party/pull/207 neglected to reset the rotations of the corner dancers in the "border" layout.

This fixes https://github.com/code-dot-org/dance-party/issues/257.
