### PR TITLE
sprites make relative changes for most properties

### DIFF
--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -854,21 +854,24 @@ module.exports = class DanceParty {
    * @param {string} range
    */
   startMapping(sprite, property, range) {
+    if (!sprite) {
+      return;
+    }
+
     // id's should be the same as long as the property/range are the same. they
     // need not be unique across sprites
     const id = [property, range].join('-');
+
+    // Grab the initial value so that changes can be relative
+    const initialValue = sprite[property];
     const behavior = new Behavior(sprite => {
-      var energy = this.getEnergy(range);
-      if (property === "x") {
-        energy = Math.round(this.p5_.map(energy, 0, 255, 50, 350));
-      } else if (property === "y") {
-        energy = Math.round(this.p5_.map(energy, 0, 255, 350, 50));
-      } else if (property === "scale") {
-        energy = this.p5_.map(energy, 0, 255, 0.5, 1.5);
-      } else if (property === "width" || property === "height") {
-        energy = this.p5_.map(energy, 0, 255, 50, 150);
-      } else if (property === "rotation" || property === "direction") {
-        energy = Math.round(this.p5_.map(energy, 0, 255, -180, 180));
+      let energy = this.getEnergy(range);
+      if (property === "x" || property === "y") {
+        energy = Math.round(this.p5_.map(energy, 0, 255, initialValue - 150, initialValue + 150));
+      } else if (property === "scale" || property === "width" || property === "height") {
+        energy = this.p5_.map(energy, 0, 255, initialValue * 0.5, initialValue * 1.5);
+      } else if (property === "rotation") {
+        energy = Math.round(this.p5_.map(energy, 0, 255, initialValue - 90, initialValue + 90));
       } else if (property === "tint") {
         energy = Math.round(this.p5_.map(energy, 0, 255, 0, 360));
         energy = "hsb(" + energy + ",100%,100%)";


### PR DESCRIPTION
This is one part of https://github.com/code-dot-org/dance-party/issues/75

It makes it so that when we use the block that makes a sprite follow bass/treble/mid, we do so relative to the current state (except for tint).

For x, y we map to a range from (current - 150, current + 150)
For scale, width, height, we map from (current * 0.5, current * 1.5)
For rotation we map to a range (current - 90, current + 90).

I've removed the unused "direction" property.