### PR TITLE
Improve depth sorting

### DIFF
--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -371,10 +371,15 @@ module.exports = class DanceParty {
         sprite.x = position.x;
         sprite.y = position.y;
       }
+      this.adjustSpriteDepth_(sprite);
     };
     sprite.setScale = function (scale) {
       sprite.scale = scale;
+      this.adjustSpriteDepth_(sprite);
     };
+
+    this.adjustSpriteDepth_(sprite);
+
     return sprite;
   }
 
@@ -697,7 +702,9 @@ module.exports = class DanceParty {
     // that are higher.
     // We also add a fractional component based on x to avoid z-fighting (except
     // in cases where we have identical x and y).
-    group.forEach(sprite => sprite.depth = sprite.y + sprite.x / 400);
+    group.forEach(sprite => {
+      this.adjustSpriteDepth_(sprite);
+    });
   }
 
   // Properties
@@ -715,10 +722,12 @@ module.exports = class DanceParty {
 
     if (property === "scale") {
       sprite.scale = val / 100;
+      this.adjustSpriteDepth_(sprite);
     } else if (property === "width" || property === "height") {
       sprite[property] = SIZE * (val / 100);
     } else if (property === "y") {
       sprite.y = this.world.height - val;
+      this.adjustSpriteDepth_(sprite);
     } else if (property === "costume") {
       sprite.setAnimation(val);
     } else if (property === "tint" && typeof (val) === "number") {
@@ -737,6 +746,7 @@ module.exports = class DanceParty {
       sprite[property] = SIZE * (randomInt(0,100)/100);
     } else if (property === "y" || property === "x"){
       sprite[property] = randomInt(50, 350);
+      this.adjustSpriteDepth_(sprite);
     } else if (property === "rotation"){
       sprite[property] = randomInt(0, 359);
     } else if (property === "tint") {
@@ -785,6 +795,7 @@ module.exports = class DanceParty {
     if (!this.spriteExists_(sprite)) return;
     sprite.x = location.x;
     sprite.y = location.y;
+    this.adjustSpriteDepth_(sprite);
   }
 
   setDanceSpeed(sprite, speed) {
@@ -824,6 +835,14 @@ module.exports = class DanceParty {
     } else {
       return this.getCurrentTime();
     }
+  }
+
+  adjustSpriteDepth_(sprite) {
+    if (!this.spriteExists_(sprite)) {
+      return;
+    }
+
+    sprite.depth = sprite.scale + sprite.y / 400 + sprite.x / 40000;
   }
 
   // Behaviors

--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -906,6 +906,7 @@ module.exports = class DanceParty {
         energy = "hsb(" + energy + ",100%,100%)";
       }
       sprite[property] = energy;
+      this.adjustSpriteDepth_(sprite);
     }, id, [property, range]);
     this.addBehavior_(sprite, behavior);
   }

--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -842,7 +842,9 @@ module.exports = class DanceParty {
       return;
     }
 
-    sprite.depth = sprite.scale + sprite.y / 400 + sprite.x / 40000;
+    // Bias scale heavily (especially since it largely hovers around 1.0) but use
+    // Y coordinate as the first tie-breaker and X coordinate as the second.
+    sprite.depth = sprite.scale * 100 + sprite.y / 400 + sprite.x / 40000;
   }
 
   // Behaviors

--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -844,7 +844,11 @@ module.exports = class DanceParty {
 
     // Bias scale heavily (especially since it largely hovers around 1.0) but use
     // Y coordinate as the first tie-breaker and X coordinate as the second.
-    sprite.depth = sprite.scale * 100 + sprite.y / 400 + sprite.x / 40000;
+    // (Both X and Y range from 0-399 pixels.)
+    sprite.depth =
+      10000 * sprite.scale +
+      100 * sprite.y / 400 +
+      1 * sprite.x / 400;
   }
 
   // Behaviors


### PR DESCRIPTION
This makes two proposed improvements to depth sorting:

- Scale becomes the most important factor.  The bigger the scale, the higher in the stack the sprite is drawn.  Y coordinate becomes the second tie-breaker, and X coordinate becomes the third.

- We now adjust the depth of every sprite after any operation that adjusts scale, x, or y.  Previously, depth was only set for sprites in a group layout and only at the time of setting that layout.

Here are a couple examples:

In a group layout, fewer sprites in a group means a bigger scale, and now that means those bigger sprites end up in front:

![screenshot 2018-11-20 18 48 46](https://user-images.githubusercontent.com/2205926/48759116-421b5e80-ecf6-11e8-9064-d084ad9efc37.png)

Now, even after periodically adding regular sprites, depth is applied.  For sprites that are the same scale, Y coordinate becomes the tie-breaker:

![screenshot 2018-11-20 18 46 23](https://user-images.githubusercontent.com/2205926/48759114-421b5e80-ecf6-11e8-8e9d-9aedbf108aac.png)


