### PR TITLE
use a set of representative measures to modify energy

### DIFF
--- a/src/modifySongData.js
+++ b/src/modifySongData.js
@@ -1,8 +1,14 @@
-// This is derived from DanceParty.getCurrentMeasure, but don't want to explicitly
-// depend on DanceParty so that this could be easily moved to a preRender step in
-// the future.
+/**
+ * This is derived from DanceParty.getCurrentMeasure, but don't want to explicitly
+ * depend on DanceParty so that this could be easily moved to a preRender step in
+ * the future.
+ * @param {Object} songMetadata
+ * @param {Number} time - Time provided in seconds
+ */
 function getMeasureForTime(songMetadata, time) {
-  return songMetadata.bpm * ((time - songMetadata.delay) / 240) + 1;
+  const measuresPerSecond = songMetadata.bpm / 240;
+  const secondsElapsed = time - songMetadata.delay;
+  return secondsElapsed * measuresPerSecond + 1;
 }
 
 function clamp(min, max, val) {
@@ -47,6 +53,7 @@ function getFrequencyEnergy(energy, options = {}) {
   const representativeIndexRange = valueOrDefault(options.representativeIndexRange ||
     [0, energy.length]);
 
+  // Energy values are all 0+
   const nonZero = energy.slice(...representativeIndexRange).filter(e => e > 0);
   const mean = calculateMean(nonZero);
 

--- a/src/modifySongData.js
+++ b/src/modifySongData.js
@@ -43,7 +43,7 @@ function valueOrDefault(value, defaultValue) {
  */
 function getFrequencyEnergy(energy, options = {}) {
   const numDeviations = valueOrDefault(options.numDeviations, 1.5);
-  const smoothFactor = valueOrDefault(options.smoothFactor, 0.7);
+  const smoothFactor = valueOrDefault(options.smoothFactor, 0.6);
   const representativeIndexRange = valueOrDefault(options.representativeIndexRange ||
     [0, energy.length]);
 

--- a/test/unit/modifySongDataTest.js
+++ b/test/unit/modifySongDataTest.js
@@ -2,10 +2,15 @@ const test = require('tape');
 const modifySongData = require('../../src/modifySongData');
 const songData = require('../../metadata/jazzy_beats.json');
 
+function songDataWithCustomOpts(energyCustomization) {
+  return Object.assign({}, songData, { energyCustomization });
+}
+
 test('can successfully modify song data', t => {
-  const modified = modifySongData(songData, 1.5, 0.7);
+  const modified = modifySongData(songData);
   // make sure we've returned a new object
   t.ok(modified !== songData);
+  t.equal(songData.analysis.length, modified.analysis.length);
 
   // pick an arbitrary frame (just needs to be one with non-zero energy)
   const frame = 1000;
@@ -15,11 +20,38 @@ test('can successfully modify song data', t => {
 
   // again pretty weak, but make sure that modifying our params gives us different
   // energy values
-  const modifiedSmoothing = modifySongData(songData, 1.5, 0.5);
-  const modifiedDeviations = modifySongData(songData, 2, 0.7);
+  const modifiedSmoothing = modifySongData(songDataWithCustomOpts({
+    numDeviations: 1.5,
+    smoothFactor: 0.5,
+  }));
+  const modifiedDeviations = modifySongData(songDataWithCustomOpts({
+    numDeviations: 2,
+    smoothFactor: 0.7,
+  }));
 
   t.notEqual(modified.analysis[frame].energy[0], modifiedSmoothing.analysis[frame].energy[0]);
   t.notEqual(modified.analysis[frame].energy[0], modifiedDeviations.analysis[frame].energy[0]);
 
+  t.end();
+});
+
+test('can specify representativeMeasureRange', t => {
+  const modified = modifySongData(songDataWithCustomOpts({
+    // default options
+    numDeviations: 1.5,
+    smoothFactor: 0.5,
+    representativeMeasureRange: [5, 12]
+  }));
+  const modifiedRepresentativeRange = modifySongData(songDataWithCustomOpts({
+    numDeviations: 1.5,
+    smoothFactor: 0.5,
+    representativeMeasureRange: [0, 100]
+  }));
+
+  // pick an arbitrary frame (just needs to be one with non-zero energy)
+  const frame = 1000;
+
+  // changing our representativeMeasureRange should change energy levels
+  t.notEqual(modified.analysis[frame].energy[0], modifiedRepresentativeRange.analysis[frame].energy[0]);
   t.end();
 });


### PR DESCRIPTION
A second part of https://github.com/code-dot-org/dance-party/issues/75

The other piece is https://github.com/code-dot-org/dance-party/pull/442 (making movement relative instead of absolute).

This piece makes it so that when calculating the mean/standard deviation of the energy for a song, we do so across a representative set of measures (5 to 12 by default) instead of across the entire song.  We believe this range to be effective for most songs, but may want to end up tuning it for a few manually.

It is likely that we could accomplish the same sort of thing by customizing the numDeviations options on a song by song basis, but this was decided that it's easier for the human tuner to reason about representative measures.

This code all better belongs in the preRender step, but that would mean regenerating all of our song metadatas. We do think there will still be some metadata regenerated for songs where the default representative measures are no good.

The main risk here is that we make the energy levels worse for some songs.