### PR TITLE
Measure text: improve appearance & support RTL

### DIFF
--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -1059,7 +1059,7 @@ module.exports = class DanceParty {
 
       // Background rectangle.
       this.p5_.noStroke();
-      this.p5_.fill("rgba(255,255,255,.8)");
+      this.p5_.fill("rgba(0,0,0,.38)");
       if (this.rtl) {
         this.p5_.rect(399 - 13 - textWidth, 4, textWidth + 10, 28);
       } else {
@@ -1067,7 +1067,7 @@ module.exports = class DanceParty {
       }
 
       // The text.
-      this.p5_.fill("#333");
+      this.p5_.fill("white");
       if (this.rtl) {
         this.p5_.text(text, 399 - 9, 25);
       } else {

--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -55,6 +55,8 @@ module.exports = class DanceParty {
     this.i18n = i18n;
     this.resourceLoader_ = resourceLoader;
 
+    this.rtl = getComputedStyle(document.getElementById(container)).direction === "rtl";
+
     this.world = {
       height: 400,
       cues: {
@@ -1050,18 +1052,27 @@ module.exports = class DanceParty {
     if (this.showMeasureLabel && this.getCurrentMeasure() >= 1) {
       const text = `${this.i18n.measure()} ${Math.floor(Math.max(0, this.getCurrentMeasure()))}`;
 
-      // Properties that adjust textWidth.
+      // Calculate text width.
       this.p5_.textStyle(this.p5_.BOLD);
       this.p5_.textSize(20);
+      const textWidth = this.p5_.textWidth(text);
 
       // Background rectangle.
       this.p5_.noStroke();
       this.p5_.fill("rgba(255,255,255,.8)");
-      this.p5_.rect(4, 4, this.p5_.textWidth(text) + 10, 28);
+      if (this.rtl) {
+        this.p5_.rect(399 - 13 - textWidth, 4, textWidth + 10, 28);
+      } else {
+        this.p5_.rect(4, 4, this.p5_.textWidth(text) + 10, 28);
+      }
 
       // The text.
       this.p5_.fill("#333");
-      this.p5_.text(text, 9, 25);
+      if (this.rtl) {
+        this.p5_.text(text, 399 - 9, 25);
+      } else {
+        this.p5_.text(text, 9, 25);
+      }
     }
 
     if (Object.keys(events).length && this.onHandleEvents) {

--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -1060,7 +1060,7 @@ module.exports = class DanceParty {
 
       // Background rectangle.
       this.p5_.noStroke();
-      this.p5_.fill("rgba(0,0,0,.38)");
+      this.p5_.fill("rgba(255,255,255,.8)");
       if (this.rtl) {
         this.p5_.rect(399 - 13 - textWidth, 4, textWidth + 10, 28);
       } else {
@@ -1068,7 +1068,7 @@ module.exports = class DanceParty {
       }
 
       // The text.
-      this.p5_.fill("white");
+      this.p5_.fill("#333");
       if (this.rtl) {
         this.p5_.text(text, 399 - 9, 25);
       } else {

--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -1058,13 +1058,13 @@ module.exports = class DanceParty {
       // Background rectangle.
       this.p5_.noStroke();
       this.p5_.fill("rgba(255,255,255,.8)");
-      this.p5_.rect(2, 2, this.p5_.textWidth(text) + 10, 30);
+      this.p5_.rect(4, 4, this.p5_.textWidth(text) + 10, 28);
 
       // The text.
       this.p5_.fill("#333");
       this.p5_.textAlign(this.p5_.TOP, this.p5_.LEFT);
       this.p5_.textSize(20);
-      this.p5_.text(text, 7, 23);
+      this.p5_.text(text, 9, 25);
     }
 
     if (Object.keys(events).length && this.onHandleEvents) {

--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -1046,14 +1046,14 @@ module.exports = class DanceParty {
       this.p5_.pop();
     }
 
-    this.p5_.fill("black");
+    this.p5_.fill("#333");
     this.p5_.textStyle(this.p5_.BOLD);
     this.p5_.textAlign(this.p5_.TOP, this.p5_.LEFT);
     this.p5_.textSize(20);
 
     this.world.validationCallback(this.world, this, this.sprites_, events);
     if (this.showMeasureLabel && this.getCurrentMeasure() >= 1) {
-      this.p5_.text(`${this.i18n.measure()} ${Math.floor(Math.max(0, this.getCurrentMeasure()))}`, 10, 20);
+      this.p5_.text(`${this.i18n.measure()} ${Math.floor(Math.max(0, this.getCurrentMeasure()))}`, 7, 23);
     }
 
     if (Object.keys(events).length && this.onHandleEvents) {

--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -55,7 +55,8 @@ module.exports = class DanceParty {
     this.i18n = i18n;
     this.resourceLoader_ = resourceLoader;
 
-    this.rtl = window.getComputedStyle(document.getElementById(container)).direction === "rtl";
+    const containerElement = document.getElementById(container);
+    this.rtl = containerElement && window.getComputedStyle(containerElement).direction === "rtl";
 
     this.world = {
       height: 400,

--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -1046,14 +1046,13 @@ module.exports = class DanceParty {
       this.p5_.pop();
     }
 
-    this.p5_.fill("#333");
-    this.p5_.textStyle(this.p5_.BOLD);
-    this.p5_.textAlign(this.p5_.TOP, this.p5_.LEFT);
-    this.p5_.textSize(20);
-
     this.world.validationCallback(this.world, this, this.sprites_, events);
     if (this.showMeasureLabel && this.getCurrentMeasure() >= 1) {
       const text = `${this.i18n.measure()} ${Math.floor(Math.max(0, this.getCurrentMeasure()))}`;
+
+      // Properties that adjust textWidth.
+      this.p5_.textStyle(this.p5_.BOLD);
+      this.p5_.textSize(20);
 
       // Background rectangle.
       this.p5_.noStroke();
@@ -1062,8 +1061,6 @@ module.exports = class DanceParty {
 
       // The text.
       this.p5_.fill("#333");
-      this.p5_.textAlign(this.p5_.TOP, this.p5_.LEFT);
-      this.p5_.textSize(20);
       this.p5_.text(text, 9, 25);
     }
 

--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -1053,7 +1053,18 @@ module.exports = class DanceParty {
 
     this.world.validationCallback(this.world, this, this.sprites_, events);
     if (this.showMeasureLabel && this.getCurrentMeasure() >= 1) {
-      this.p5_.text(`${this.i18n.measure()} ${Math.floor(Math.max(0, this.getCurrentMeasure()))}`, 7, 23);
+      const text = `${this.i18n.measure()} ${Math.floor(Math.max(0, this.getCurrentMeasure()))}`;
+
+      // Background rectangle.
+      this.p5_.noStroke();
+      this.p5_.fill("rgba(255,255,255,.8)");
+      this.p5_.rect(2, 2, this.p5_.textWidth(text) + 10, 30);
+
+      // The text.
+      this.p5_.fill("#333");
+      this.p5_.textAlign(this.p5_.TOP, this.p5_.LEFT);
+      this.p5_.textSize(20);
+      this.p5_.text(text, 7, 23);
     }
 
     if (Object.keys(events).length && this.onHandleEvents) {

--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -55,7 +55,7 @@ module.exports = class DanceParty {
     this.i18n = i18n;
     this.resourceLoader_ = resourceLoader;
 
-    this.rtl = getComputedStyle(document.getElementById(container)).direction === "rtl";
+    this.rtl = window.getComputedStyle(document.getElementById(container)).direction === "rtl";
 
     this.world = {
       height: 400,


### PR DESCRIPTION
- Colour goes from pure black to what we use elsewhere on the page for black.
- Text is now equidistant from top and left edges.
- A light rectangle behind the text helps it to be seen against all backgrounds.  (The rectangle has dynamic width based on text width.)
- We render properly for both LTR & RTL.  (Detection is done on the `div` containing the dance party.)

### before

![screenshot 2018-11-22 12 22 07](https://user-images.githubusercontent.com/2205926/48876330-92f39a00-ee51-11e8-8da0-f09c72890d87.png)

### after

#### LTR

![screenshot 2018-11-27 12 08 19](https://user-images.githubusercontent.com/2205926/49051764-4dfaa980-f23d-11e8-8a47-fdfc7ebf9e88.png)

#### RTL

![screenshot 2018-11-27 12 08 43](https://user-images.githubusercontent.com/2205926/49051767-518e3080-f23d-11e8-9980-0a6d5462d4d8.png)




