### PR TITLE
The "spotlight" effect should always set a stroke before drawing

### DIFF
--- a/src/Effects.js
+++ b/src/Effects.js
@@ -578,6 +578,7 @@ module.exports = class Effects {
         }
         p5.push();
         p5.noFill();
+        p5.stroke('#000');
         p5.strokeWeight(600);
         this.x+=this.dx+randomNumber(-1,1);
         this.y+=this.dy+randomNumber(-1,1);


### PR DESCRIPTION
Fixes:

> Spotlight Foreground does not work with Stars Background.