### PR TITLE
Clear background color in reset()

### DIFF
--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -191,6 +191,7 @@ module.exports = class DanceParty {
     }
     this.p5_.noLoop();
 
+    this.world.background_color = null;
     this.world.fg_effect = null;
     this.world.bg_effect = null;
   }


### PR DESCRIPTION
Fixes this error, logged [here](https://docs.google.com/document/d/1XD98REpm3jpjbm9lgbwZsRgMwqi30E3DBogbQrr-rls/edit?usp=sharing) by @breville:

> Background color isn't reset when no longer used. In this case, I had set background color to red in an earlier version of the program.  Now, whenever I press Reset, I end up with a bright red background again.


**Solution:** Set background color to `null` in `reset()`.