### PR TITLE
Draw pineapple graphic to a temp drawing buffer

### DIFF
--- a/src/Effects.js
+++ b/src/Effects.js
@@ -466,6 +466,9 @@ module.exports = class Effects {
             life: 5,
           });
         }
+        this.image = p5.createGraphics(75, 130);
+        this.image.scale(7);
+        drawPineapple(this.image.drawingContext);
       },
       draw: function () {
         for (let i = 0; i < this.pineappleList.length; i++) {
@@ -473,8 +476,8 @@ module.exports = class Effects {
           const pineapple = this.pineappleList[i];
           p5.translate(pineapple.x, pineapple.y);
           p5.rotate(pineapple.rot);
-          p5.scale(pineapple.life / 20);
-          drawPineapple(p5._renderer.drawingContext);
+          p5.scale(pineapple.life / 20 / (7 * p5.pixelDensity()));
+          p5.drawingContext.drawImage(this.image.elt, -35, -65);
           pineapple.life--;
           if (pineapple.life < 0) {
             pineapple.x = randomNumber(10, 390);


### PR DESCRIPTION
Fix for slow pineapple effect performance on iPhone 5s.

![image](https://user-images.githubusercontent.com/413693/49251178-ba101580-f3d5-11e8-8d92-aabaec0d680c.png)