### PR TITLE
Change canvas to optional dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2797,7 +2797,7 @@
       "version": "1.6.13",
       "resolved": "https://registry.npmjs.org/canvas/-/canvas-1.6.13.tgz",
       "integrity": "sha512-XAfzfEOHZ3JIPjEV+WSI6PpISgUta3dgmndWbsajotz+0TQOX/jDpp2kawjRERatOGv9sMMzk5auB3GKEKA6hg==",
-      "dev": true,
+      "optional": true,
       "requires": {
         "nan": "^2.10.0"
       }
@@ -9099,7 +9099,7 @@
       "version": "2.11.1",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
       "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
-      "dev": true
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.7.0",
     "babelify": "^6.3.0",
-    "canvas": "^1.6.13",
     "codecov": "^3.1.0",
     "data-urls": "^1.1.0",
     "eslint": "^2.8.0",
@@ -51,6 +50,9 @@
     "webpack": "4.19.1",
     "webpack-cli": "^2.1.5",
     "webpack-dev-server": "^3.1.4"
+  },
+  "optionalDependencies": {
+    "canvas": "^1.6.13"
   },
   "bugs": {
     "url": "https://github.com/code-dot-org/dance-party/issues"

--- a/test/visual/helpers/createBackgroundScreenshot.js
+++ b/test/visual/helpers/createBackgroundScreenshot.js
@@ -6,7 +6,13 @@ const fs = require('fs');
   Set the background to given effect and save a screenshot to pathname
  */
 async function createBackgroundScreenshot(effectName, pathname, palette){
-  let nativeAPI = await helpers.createDanceAPI();
+  let nativeAPI;
+  try {
+    nativeAPI = await helpers.createDanceAPI();
+  } catch (e) {
+    console.error(e);
+    return;
+  }
   nativeAPI.p5_.randomSeed(0);
   nativeAPI.p5_.noiseSeed(0);
   nativeAPI.setBackgroundEffect(effectName, palette);


### PR DESCRIPTION
This unblocks onboarding to the dance party repository as installing canvas was causing errors: https://github.com/Automattic/node-canvas/issues/822

Canvas is only required to run the visual tests, which does not block contributors adding backgrounds.