### PR TITLE
Look up sprites by name property, not variable reference

### DIFF
--- a/levels/hourOfCode.js
+++ b/levels/hourOfCode.js
@@ -4,7 +4,7 @@ module.exports = {
       var my_first_dancer;
 
       whenSetup(function () {
-        my_first_dancer = makeNewDanceSprite("CAT", my_first_dancer, {x: 200, y: 200});
+        makeNewDanceSprite("CAT", "my_first_dancer", {x: 200, y: 200});
       });
     `,
     validationCode: `
@@ -25,11 +25,11 @@ module.exports = {
       var new_dancer;
 
       whenSetup(function () {
-        new_dancer = makeNewDanceSprite("MOOSE", new_dancer, {x: 200, y: 200});
+        makeNewDanceSprite("MOOSE", "new_dancer", {x: 200, y: 200});
       });
 
       atTimestamp(4, "measures", function () {
-        changeMoveLR(new_dancer, MOVES.Floss, -1);
+        changeMoveLR("new_dancer", MOVES.Floss, -1);
       });
     `,
     validationCode: `
@@ -58,12 +58,12 @@ module.exports = {
       var fancy_dancer;
 
       whenSetup(function () {
-        fancy_dancer = makeNewDanceSprite("ROBOT", fancy_dancer, {x: 200, y: 200});
+        makeNewDanceSprite("ROBOT", "fancy_dancer", {x: 200, y: 200});
         setBackgroundEffectWithPalette("disco");
       });
 
       atTimestamp(4, "measures", function () {
-        changeMoveLR(fancy_dancer, MOVES.Dab, -1);
+        changeMoveLR("fancy_dancer", MOVES.Dab, -1);
       });
     `,
     validationCode: `
@@ -85,20 +85,20 @@ module.exports = {
 
       whenSetup(function () {
         setBackgroundEffectWithPalette("diamonds");
-        backup_dancer1 = makeNewDanceSprite("CAT", backup_dancer1, {x: 300, y: 200});
-        setProp(backup_dancer1, "scale", 50);
-        backup_dancer2 = makeNewDanceSprite("ROBOT", backup_dancer2, {x: 100, y: 200});
-        setProp(backup_dancer2, "scale", 50);
-        lead_dancer = makeNewDanceSprite("MOOSE", lead_dancer, {x: 200, y: 200});
+        makeNewDanceSprite("CAT", "backup_dancer1", {x: 300, y: 200});
+        setProp("backup_dancer1", "scale", 50);
+        makeNewDanceSprite("ROBOT", "backup_dancer2", {x: 100, y: 200});
+        setProp("backup_dancer2", "scale", 50);
+        makeNewDanceSprite("MOOSE", "lead_dancer", {x: 200, y: 200});
       });
 
       everySeconds(2, "measures", function () {
-        changeMoveLR(lead_dancer, "next", -1);
+        changeMoveLR("lead_dancer", "next", -1);
       });
 
       atTimestamp(4, "measures", function () {
-        changeMoveLR(backup_dancer1, MOVES.Fresh, -1);
-        changeMoveLR(backup_dancer2, MOVES.Fresh, 1);
+        changeMoveLR("backup_dancer1", MOVES.Fresh, -1);
+        changeMoveLR("backup_dancer2", MOVES.Fresh, 1);
       });
     `,
     validationCode: `
@@ -126,15 +126,15 @@ module.exports = {
 
       whenSetup(function () {
         setBackgroundEffectWithPalette("rainbow");
-        left_shark = makeNewDanceSprite("MOOSE", left_shark, {x: 100, y: 200});
-        right_pineapple = makeNewDanceSprite("ROBOT", right_pineapple, {x: 300, y: 200});
-        startMapping(left_shark, "height", "bass");
-        startMapping(right_pineapple, "scale", "bass");
+        makeNewDanceSprite("MOOSE", "left_shark", {x: 100, y: 200});
+        makeNewDanceSprite("ROBOT", "right_pineapple", {x: 300, y: 200});
+        startMapping("left_shark", "height", "bass");
+        startMapping("right_pineapple", "scale", "bass");
       });
 
       everySeconds(2, "measures", function () {
-        changeMoveLR(left_shark, "next", -1);
-        changeMoveLR(right_pineapple, "next", 1);
+        changeMoveLR("left_shark", "next", -1);
+        changeMoveLR("right_pineapple", "next", 1);
       });
     `,
     validationCode: `
@@ -163,16 +163,16 @@ module.exports = {
 
       whenSetup(function () {
         setBackgroundEffectWithPalette("splatter");
-        left_dancer = makeNewDanceSprite("CAT", left_dancer, {x: 100, y: 200});
-        right_dancer = makeNewDanceSprite("ROBOT", right_dancer, {x: 300, y: 200});
+        makeNewDanceSprite("CAT", "left_dancer", {x: 100, y: 200});
+        makeNewDanceSprite("ROBOT", "right_dancer", {x: 300, y: 200});
       });
 
       everySeconds(2, "measures", function () {
-        changeMoveLR(left_dancer, "next", -1);
+        changeMoveLR("left_dancer", "next", -1);
       });
 
       whenKey("up", function () {
-        doMoveLR(right_dancer, MOVES.XArmsUp, -1);
+        doMoveLR("right_dancer", MOVES.XArmsUp, -1);
       });
     `,
     validationCode: `

--- a/levels/spriteDance.js
+++ b/levels/spriteDance.js
@@ -4,26 +4,26 @@ module.exports = {
       `	
       var lead_dancer;	
        whenSetup(function () {	
-        lead_dancer = makeNewDanceSprite("CAT", lead_dancer, {x: 200, y: 200});	
+        makeNewDanceSprite("CAT", "lead_dancer", {x: 200, y: 200});	
       });	
        everySeconds(2, "measures", function () {	
-        changeMoveLR(lead_dancer, 3, -1);	
+        changeMoveLR("lead_dancer", 3, -1);	
       });	
        everySeconds(4, "measures", function () {	
-        changeMoveLR(lead_dancer, 1, -1);	
-        setProp(lead_dancer, "scale", 50);	
+        changeMoveLR("lead_dancer", 1, -1);	
+        setProp("lead_dancer", "scale", 50);	
       });	
     `,
       `	
       var lead_dancer;	
        whenSetup(function () {	
-        lead_dancer = makeNewDanceSprite("CAT", lead_dancer, {x: 200, y: 200});	
+        makeNewDanceSprite("CAT", "lead_dancer", {x: 200, y: 200});	
       });	
        everySeconds(4, "measures", function () {	
-        changeMoveLR(lead_dancer, 1, -1);	
+        changeMoveLR("lead_dancer", 1, -1);	
       });	
        everySeconds(2, "measures", function () {	
-        changeMoveLR(lead_dancer, 3, -1);	
+        changeMoveLR("lead_dancer", 3, -1);	
       });	
     `,
     ],

--- a/src/api.js
+++ b/src/api.js
@@ -1,7 +1,7 @@
 module.exports = class DanceAPI {
   constructor(nativeAPI) {
     const sprites = [];
-    
+
     const lookupSprite = spriteName =>
       sprites.find(sprite => sprite.name === spriteName);
 

--- a/src/api.js
+++ b/src/api.js
@@ -1,6 +1,17 @@
 module.exports = class DanceAPI {
   constructor(nativeAPI) {
     const sprites = [];
+    
+    const lookupSprite = spriteName =>
+      sprites.find(sprite => sprite.name === spriteName);
+
+    const enforceUniqueName = name => {
+      sprites.forEach(sprite => {
+        if (sprite.name === name) {
+          sprite.name = undefined;
+        }
+      });
+    };
 
     return {
       setBackground: color => {
@@ -30,21 +41,20 @@ module.exports = class DanceAPI {
         sprites.push(nativeAPI.makeNewDanceSprite(costume, null, location));
       },
       makeNewDanceSprite: (costume, name, location) => {
-        return Number(
-          sprites.push(nativeAPI.makeNewDanceSprite(costume, name, location)) - 1
-        );
+        enforceUniqueName(name);
+        sprites.push(nativeAPI.makeNewDanceSprite(costume, name, location));
       },
       makeNewDanceSpriteGroup: (n, costume, layout) => {
         nativeAPI.makeNewDanceSpriteGroup(n, costume, layout);
       },
-      getCurrentDance: spriteIndex => {
-        return nativeAPI.getCurrentDance(sprites[spriteIndex]);
+      getCurrentDance: spriteName => {
+        return nativeAPI.getCurrentDance(lookupSprite(spriteName));
       },
-      changeMoveLR: (spriteIndex, move, dir) => {
-        nativeAPI.changeMoveLR(sprites[spriteIndex], move, dir);
+      changeMoveLR: (spriteName, move, dir) => {
+        nativeAPI.changeMoveLR(lookupSprite(spriteName), move, dir);
       },
-      doMoveLR: (spriteIndex, move, dir) => {
-        nativeAPI.doMoveLR(sprites[spriteIndex], move, dir);
+      doMoveLR: (spriteName, move, dir) => {
+        nativeAPI.doMoveLR(lookupSprite(spriteName), move, dir);
       },
       changeMoveEachLR: (group, move, dir) => {
         nativeAPI.changeMoveEachLR(group, move, dir);
@@ -55,11 +65,11 @@ module.exports = class DanceAPI {
       layoutSprites: (group, format) => {
         nativeAPI.layoutSprites(group, format);
       },
-      setTint: (spriteIndex, val) => {
-        nativeAPI.setTint(sprites[spriteIndex], val);
+      setTint: (spriteName, val) => {
+        nativeAPI.setTint(lookupSprite(spriteName), val);
       },
-      setTintInline: (spriteIndex, val) => {
-        nativeAPI.setTint(sprites[spriteIndex], val);
+      setTintInline: (spriteName, val) => {
+        nativeAPI.setTint(lookupSprite(spriteName), val);
       },
       setTintEach: (group, val) => {
         nativeAPI.setTintEach(group, val);
@@ -67,32 +77,32 @@ module.exports = class DanceAPI {
       setTintEachInline: (group, val) => {
         nativeAPI.setTintEach(group, val);
       },
-      setVisible: (spriteIndex, val) => {
-        nativeAPI.setVisible(sprites[spriteIndex], val);
+      setVisible: (spriteName, val) => {
+        nativeAPI.setVisible(lookupSprite(spriteName), val);
       },
       setVisibleEach: (group, val) => {
         nativeAPI.setVisibleEach(group, val);
       },
-      setProp: (spriteIndex, property, val) => {
-        nativeAPI.setProp(sprites[spriteIndex], property, val);
+      setProp: (spriteName, property, val) => {
+        nativeAPI.setProp(lookupSprite(spriteName), property, val);
       },
       setPropEach: (group, property, val) => {
         nativeAPI.setPropEach(group, property, val);
       },
-      setPropRandom: (spriteIndex, property) => {
-        nativeAPI.setPropRandom(sprites[spriteIndex], property);
+      setPropRandom: (spriteName, property) => {
+        nativeAPI.setPropRandom(lookupSprite(spriteName), property);
       },
-      getProp: (spriteIndex, property, val) => {
-        return nativeAPI.setProp(sprites[spriteIndex], property, val);
+      getProp: (spriteName, property, val) => {
+        return nativeAPI.setProp(lookupSprite(spriteName), property, val);
       },
-      changePropBy: (spriteIndex, property, val) => {
-        nativeAPI.changePropBy(sprites[spriteIndex], property, val);
+      changePropBy: (spriteName, property, val) => {
+        nativeAPI.changePropBy(lookupSprite(spriteName), property, val);
       },
-      jumpTo: (spriteIndex, location) => {
-        nativeAPI.jumpTo(sprites[spriteIndex], location);
+      jumpTo: (spriteName, location) => {
+        nativeAPI.jumpTo(lookupSprite(spriteName), location);
       },
-      setDanceSpeed: (spriteIndex, speed) => {
-        nativeAPI.setDanceSpeed(sprites[spriteIndex], speed);
+      setDanceSpeed: (spriteName, speed) => {
+        nativeAPI.setDanceSpeed(lookupSprite(spriteName), speed);
       },
       setDanceSpeedEach: (group, speed) => {
         nativeAPI.setDanceSpeedEach(group, speed);
@@ -103,11 +113,11 @@ module.exports = class DanceAPI {
       getTime: unit => {
         return Number(nativeAPI.getTime(unit));
       },
-      startMapping: (spriteIndex, property, val) => {
-        return nativeAPI.startMapping(sprites[spriteIndex], property, val);
+      startMapping: (spriteName, property, val) => {
+        return nativeAPI.startMapping(lookupSprite(spriteName), property, val);
       },
-      stopMapping: (spriteIndex, property, val) => {
-        return nativeAPI.stopMapping(sprites[spriteIndex], property, val);
+      stopMapping: (spriteName, property, val) => {
+        return nativeAPI.stopMapping(lookupSprite(spriteName), property, val);
       },
       changeColorBy: (input, method, amount) => {
         return nativeAPI.changeColorBy(input, method, amount);

--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -336,7 +336,7 @@ module.exports = class DanceParty {
   // Block Functions
   //
 
-  makeNewDanceSprite(costume, _, location) {
+  makeNewDanceSprite(costume, name, location) {
 
     // Default to first dancer if selected a dancer that doesn't exist
     // to account for low-bandwidth mode limited character set
@@ -352,6 +352,10 @@ module.exports = class DanceParty {
     }
 
     var sprite = this.p5_.createSprite(location.x, location.y);
+    
+    if (name) {
+      sprite.name = name;
+    }
 
     sprite.style = costume;
     this.getGroupByName_(costume).add(sprite);

--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -352,7 +352,7 @@ module.exports = class DanceParty {
     }
 
     var sprite = this.p5_.createSprite(location.x, location.y);
-    
+
     if (name) {
       sprite.name = name;
     }

--- a/test/unit/eventsTest.js
+++ b/test/unit/eventsTest.js
@@ -84,11 +84,11 @@ test('non-conflicting everySeconds cues', async t => {
   nativeAPI.world.fullLengthMoveCount = 4;
   nativeAPI.world.restMoveCount = 1;
   const userCode = `
-    const moose = makeNewDanceSprite("MOOSE");
-    const robot = makeNewDanceSprite("ROBOT");
+    makeNewDanceSprite("MOOSE", "moose");
+    makeNewDanceSprite("ROBOT", "robot");
 
-    everySeconds(1, "seconds", () => changeMoveLR(moose, "next"));
-    everySeconds(2, "seconds", () => changeMoveLR(robot, "next"));
+    everySeconds(1, "seconds", () => changeMoveLR("moose", "next"));
+    everySeconds(2, "seconds", () => changeMoveLR("robot", "next"));
   `;
   const interpretedAPI = injectInterpreted(nativeAPI, interpreted, userCode);
 


### PR DESCRIPTION
Depends on https://github.com/code-dot-org/code-dot-org/pull/31120
Previously, sprites were variables whose value was the id reference provided from native. This changes the generated code and sprite lab library so that sprites are instead identified and referenced by name property. Right now, this is intended to be basically a no-op functionality change. Mostly, that just means that sprite names must be unique and there is no way to change a sprite's name after its creation. I could see either or both of those changing at some point, but for now maintaining existing behavior seemed reasonable.

Similar to https://github.com/code-dot-org/code-dot-org/pull/30979