### PR TITLE
Use the same asset version used in the cdo repo

### DIFF
--- a/src/ResourceLoader.js
+++ b/src/ResourceLoader.js
@@ -1,4 +1,4 @@
-const ASSET_BASE = "https://curriculum.code.org/images/sprites/dance_20181120/";
+const ASSET_BASE = "https://curriculum.code.org/images/sprites/dance_20181127/";
 
 /**
  * The resource loader class abstracts network-dependent operations, allowing


### PR DESCRIPTION
The CDO repository uses the `https://curriculum.code.org/images/sprites/dance_20181127/` folder for assets. Let's update the default version in dance party to point at the same direction.

https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/dance/Dance.js#L401

Part of work to close the loop on sprites and de-duplicate spritesheet.