### PR TITLE
Raining emoji touch ups

### DIFF
--- a/src/Effects.js
+++ b/src/Effects.js
@@ -1613,7 +1613,7 @@ module.exports = class Effects {
           this.emojiList.push({
             x: randomNumber(0, 350),
             y: -50,
-            size: randomNumber(25, 50),
+            size: randomNumber(50, 90),
             image: this.emojiTypes[randomNumber(0, 4)],
           });
         }
@@ -1624,7 +1624,7 @@ module.exports = class Effects {
             this.emojiList.splice(i, 1);
           }
           p5.push();
-          p5.image(emoji.image, emoji.x, emoji.y, emoji.size, emoji.size);
+          p5.drawingContext.drawImage(emoji.image.elt, emoji.x, emoji.y, emoji.size, emoji.size);
           p5.pop();
         }
       },

--- a/src/Effects.js
+++ b/src/Effects.js
@@ -1451,7 +1451,7 @@ module.exports = class Effects {
         }
         this.image = p5.createGraphics(100, 100);
         this.image.scale(3);
-        drawSmiley(this.image.drawingContext);
+        drawSmiley(this.image.drawingContext, 0.8);
       },
       draw: function (context) {
         const centroid = context.centroid;
@@ -1589,7 +1589,7 @@ module.exports = class Effects {
 
         this.imageSmiley = p5.createGraphics(100, 100);
         this.imageSmiley.scale(3);
-        drawSmiley(this.imageSmiley.drawingContext);
+        drawSmiley(this.imageSmiley.drawingContext, 1.0);
         this.emojiTypes.push(this.imageSmiley);
 
         this.imageStarstruck = p5.createGraphics(100, 100);

--- a/src/shapes/smiley.js
+++ b/src/shapes/smiley.js
@@ -1,4 +1,4 @@
-module.exports = function drawSmiley(ctx) {
+module.exports = function drawSmiley(ctx, alpha) {
   ctx.save();
   ctx.strokeStyle = 'rgba(0,0,0,0)';
   ctx.lineCap = 'butt';
@@ -6,7 +6,7 @@ module.exports = function drawSmiley(ctx) {
   ctx.miterLimit = 4;
   ctx.save();
   ctx.fillStyle = "#ffdf40";
-  ctx.globalAlpha = 0.8;
+  ctx.globalAlpha = alpha;
   ctx.beginPath();
   ctx.arc(8.5,8,8,0,6.283185307179586,true);
   ctx.closePath();


### PR DESCRIPTION
Wanted to polish two things in this background - make the transparency consistent for all smile types and fix the cropping of the starstruck emoji.

Before:
![Screenshot from 2019-11-08 09-24-29](https://user-images.githubusercontent.com/2959170/68501647-75ab0d80-0213-11ea-9789-44621a4c1cba.png)

After: 
![Screenshot from 2019-11-08 10-36-45](https://user-images.githubusercontent.com/2959170/68501729-aee37d80-0213-11ea-8e78-cb66afb1e62d.png)

cc: @yugreta 