### PR TITLE
Add alternateMoves library function

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -62,6 +62,9 @@ module.exports = class DanceAPI {
       doMoveEachLR: (group, move, dir) => {
         nativeAPI.doMoveEachLR(group, move, dir);
       },
+      toggleBetween: (group, n, move1, move2) => {
+        nativeAPI.toggleBetween(group, n, move1, move2);
+      },
       layoutSprites: (group, format) => {
         nativeAPI.layoutSprites(group, format);
       },

--- a/src/api.js
+++ b/src/api.js
@@ -62,8 +62,8 @@ module.exports = class DanceAPI {
       doMoveEachLR: (group, move, dir) => {
         nativeAPI.doMoveEachLR(group, move, dir);
       },
-      toggleBetween: (group, n, move1, move2) => {
-        nativeAPI.toggleBetween(group, n, move1, move2);
+      alternateMoves: (group, n, move1, move2) => {
+        nativeAPI.alternateMoves(group, n, move1, move2);
       },
       layoutSprites: (group, format) => {
         nativeAPI.layoutSprites(group, format);

--- a/src/p5.dance.interpreted.js
+++ b/src/p5.dance.interpreted.js
@@ -173,13 +173,6 @@ function whenPeak(range, func) {
   });
 }
 
-function alternateMoves(group, n, move1, move2) {
-  changeMoveEachLR(group, move1, -1);
-  everySeconds(n, "measures", function () {
-    toggleBetween(group, n, move1, move2);
-  });
-}
-
 /**
  * @param {number} timestamp
  * @param {string} unit - Should be "measures" or "seconds"

--- a/src/p5.dance.interpreted.js
+++ b/src/p5.dance.interpreted.js
@@ -173,6 +173,13 @@ function whenPeak(range, func) {
   });
 }
 
+function alternateMoves(group, n, move1, move2) {
+  changeMoveEachLR(group, move1, -1);
+  everySeconds(n, "measures", function () {
+    toggleBetween(group, n, move1, move2);
+  });
+}
+
 /**
  * @param {number} timestamp
  * @param {string} unit - Should be "measures" or "seconds"

--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -568,6 +568,15 @@ module.exports = class DanceParty {
     return this.sprites_by_type_[group];
   }
 
+  toggleBetween(group, n, move1, move2) {
+    let currentMeasure = Math.floor(this.getCurrentMeasure());
+    if (Math.ceil(currentMeasure / n) % 2 == 0) {
+      this.changeMoveEachLR(group, move2, -1)
+    } else {
+      this.changeMoveEachLR(group, move1, 1)
+    }
+  }
+
   changeMoveEachLR(group, move, dir) {
     group = this.getGroupByName_(group);
     if ((move === "rand") && (group.length>0)) {

--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -571,9 +571,9 @@ module.exports = class DanceParty {
   toggleBetween(group, n, move1, move2) {
     let currentMeasure = Math.floor(this.getCurrentMeasure());
     if (Math.ceil(currentMeasure / n) % 2 == 0) {
-      this.changeMoveEachLR(group, move2, -1)
+      this.changeMoveEachLR(group, move2, -1);
     } else {
-      this.changeMoveEachLR(group, move1, 1)
+      this.changeMoveEachLR(group, move1, 1);
     }
   }
 

--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -456,8 +456,13 @@ module.exports = class DanceParty {
   // Dance Moves
 
   alternateMoves(group, n, move1, move2) {
+    // Maximum of 10 events per second
+    // Our fastest song is 169bpm
+    // This allows events on eighth-notes in that song.
+    n = Math.max(0.1, n);
+
     group = this.getGroupByName_(group);
-    let currentMeasure = Math.floor(this.getCurrentMeasure());
+    let currentMeasure = this.getCurrentMeasure();
     if (currentMeasure === 0) {
       currentMeasure = 1;
     }
@@ -1157,12 +1162,12 @@ module.exports = class DanceParty {
       title,
     };
 
-    let currentMeasure = Math.floor(this.getCurrentMeasure());
+    let currentMeasure = this.getCurrentMeasure();
     this.sprites_.forEach(sprite => {
       if (sprite.alternatingMoveInfo) {
         let alternatingMoveInfo = sprite.alternatingMoveInfo;
-        let val = Math.floor((currentMeasure - sprite.alternatingMoveInfo.start) / sprite.alternatingMoveInfo.cadence);
-        if (val % 2 == 0) {
+        let quotient = Math.floor((currentMeasure - sprite.alternatingMoveInfo.start) / sprite.alternatingMoveInfo.cadence);
+        if (quotient % 2 == 0) {
           if (sprite.alternatingMoveInfo.current != 1) {
             this.changeMoveLR(sprite, sprite.alternatingMoveInfo.move1, -1);
             sprite.alternatingMoveInfo = alternatingMoveInfo;

--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -1164,17 +1164,12 @@ module.exports = class DanceParty {
         let val = Math.floor((currentMeasure - sprite.alternatingMoveInfo.start) / sprite.alternatingMoveInfo.cadence);
         if (val % 2 == 0) {
           if (sprite.alternatingMoveInfo.current != 1) {
-            // set move1
-            console.log(`${currentMeasure}: set 1`);
-
             this.changeMoveLR(sprite, sprite.alternatingMoveInfo.move1, -1);
             sprite.alternatingMoveInfo = alternatingMoveInfo;
             sprite.alternatingMoveInfo.current = 1;
           }
         } else {
           if (sprite.alternatingMoveInfo.current != 2) {
-            // set move2
-            console.log(`${currentMeasure}: set 2`);
             this.changeMoveLR(sprite, sprite.alternatingMoveInfo.move2, 1);
             sprite.alternatingMoveInfo = alternatingMoveInfo;
             sprite.alternatingMoveInfo.current = 2;


### PR DESCRIPTION
Will be used for a new block:
![image](https://user-images.githubusercontent.com/8787187/68519910-dacd2600-0248-11ea-81b2-7ae43976e556.png)

Alternates between two moves at a given cadence. Implementing by adding `alternatingMovesInfo` to the sprite object, and checking in the draw loop whether the move should be switched. `alternatingMovesInfo` is reset in `changeMoveLR` so that the sprite stops alternating if another block changes the move. 