### PR TITLE
Use degree mode for stars background and foreground

### DIFF
--- a/src/Effects.js
+++ b/src/Effects.js
@@ -1363,7 +1363,7 @@ module.exports = class Effects {
       stars: [],
       resetStars: function () {
         for (let i = 0; i < 100; i++) {
-          let theta = p5.random(0, p5.TWO_PI);
+          let theta = p5.random(0, 360);
           let velocity = p5.random(4,12);
           this.stars.push({
             color: randomColor(255, 255, 100),
@@ -1375,7 +1375,7 @@ module.exports = class Effects {
         }
       },
       draw: function () {
-        p5.angleMode(p5.RADIANS);
+        p5.angleMode(p5.DEGREES);
         p5.noStroke();
         if (this.stars.length === 0) {
           this.resetStars();
@@ -1548,7 +1548,7 @@ module.exports = class Effects {
       numStars: 9,
 
       init: function () {
-        p5.angleMode(p5.RADIANS);
+        p5.angleMode(p5.DEGREES);
         this.colorIndex = 0;
         this.stars = [];
         for (var i = 0; i < this.numStars; i++) {

--- a/src/shapes/star.js
+++ b/src/shapes/star.js
@@ -1,9 +1,9 @@
 // Star helper function from https://p5js.org/examples/form-star.html
 module.exports = function drawStar(p5, x, y, radius1, radius2, numPoints) {
-  let angle = p5.TWO_PI / numPoints;
+  let angle = 360 / numPoints;
   let halfAngle = angle / 2.0;
   p5.beginShape();
-  for (let a = 0; a < p5.TWO_PI; a += angle) {
+  for (let a = 0; a < 360; a += angle) {
     let sx = x + p5.cos(a) * radius2;
     let sy = y + p5.sin(a) * radius2;
     p5.vertex(sx, sy);


### PR DESCRIPTION
Most of our effects use degree mode, but these stars effects were using radian mode. This led to issues when you combine a background effect that used degrees with the exploding_stars foreground effect that used radians:
Before:
![image](https://user-images.githubusercontent.com/8787187/68620977-806bd980-0483-11ea-942b-b8848d5dd04a.png)

After:
![image](https://user-images.githubusercontent.com/8787187/68620937-69c58280-0483-11ea-8701-b60d3ad13c35.png)
