### PR TITLE
Added left/right column, top/bottom row, and diamond to sprite layouts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@code-dot-org/dance-party",
-  "version": "0.0.52",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code-dot-org/dance-party",
-  "version": "0.0.52",
+  "version": "1.0.0",
   "description": "",
   "main": "dist/main.js",
   "scripts": {

--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -636,6 +636,36 @@ module.exports = class DanceParty {
     const maxY = 400 - 40;
     const radiansToDegrees = 180 / Math.PI;
     const maxCircleRadius = 165;
+    function createColumn(group, location) {
+      for (let i=0; i<count; i++) {
+        const sprite = group[i];
+        sprite.x = location;
+        sprite.y = (i+1) * (400 / (count + 1));
+        sprite.rotation = 0;
+      }
+    }
+
+    function createRow(group, location) {
+      for (let i=0; i<count; i++) {
+        const sprite = group[i];
+        sprite.x = (i+1) * (400 / (count + 1));
+        sprite.y = location;
+        sprite.rotation = 0;
+      }
+    }
+
+    let createSquare = group => {
+      const pct = this.p5_.constrain(count / 10, 0, 1);
+      const radius = this.p5_.lerp(0, 100, pct);
+      const size = Math.ceil(Math.sqrt(count));
+      group.forEach((sprite, i) => {
+        const row = Math.floor(i / size);
+        const col = i % size;
+        sprite.x = this.p5_.lerp(200 - radius, 200 + radius, col / (size - 1));
+        sprite.y = this.p5_.lerp(200 - radius, 200 + radius, row / (size - 1));
+        sprite.rotation = 0;
+      });
+    }
 
     if (format === "circle") {
       // Adjust radius of circle and size of the sprite according to number of
@@ -706,30 +736,27 @@ module.exports = class DanceParty {
         sprite.rotation = 0;
       });
     } else if (format === "inner") {
-      const pct = this.p5_.constrain(count / 10, 0, 1);
-      const radius = this.p5_.lerp(0, 100, pct);
-      const size = Math.ceil(Math.sqrt(count));
+      createSquare(group);
+    } else if (format === "diamond") {
+      createSquare(group);
       group.forEach((sprite, i) => {
-        const row = Math.floor(i / size);
-        const col = i % size;
-        sprite.x = this.p5_.lerp(200 - radius, 200 + radius, col / (size - 1));
-        sprite.y = this.p5_.lerp(200 - radius, 200 + radius, row / (size - 1));
-        sprite.rotation = 0;
+        const x = sprite.x;
+        const y = sprite.y;
+        sprite.x = (x - 200) * Math.cos(Math.PI/4) - (y - 200) * Math.sin(Math.PI/4) + 200;
+        sprite.y = (x - 200) * Math.sin(Math.PI/4) + (y - 200) * Math.cos(Math.PI/4) + 200;
       });
-    } else if (format === "row") {
-      for (let i=0; i<count; i++) {
-        const sprite = group[i];
-        sprite.x = (i+1) * (400 / (count + 1));
-        sprite.y = 200;
-        sprite.rotation = 0;
-      }
+    } else if (format === "left") {
+      createColumn(group, 100);
     } else if (format === "column") {
-      for (let i=0; i<count; i++) {
-        const sprite = group[i];
-        sprite.x = 200;
-        sprite.y = (i+1) * (400 / (count + 1));
-        sprite.rotation = 0;
-      }
+      createColumn(group, 200);
+    } else if (format === "right") {
+      createColumn(group, 300);
+    } else if (format === "top") {
+      createRow(group, 100);
+    } else if (format === "row") {
+      createRow(group, 200);
+    } else if (format === "bottom") {
+      createRow(group, 300);
     } else if (format === "border") {
       // First fill the four corners.
       // Then split remainder into 4 groups. Distribute group one along the top,

--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -637,6 +637,7 @@ module.exports = class DanceParty {
     const radiansToDegrees = 180 / Math.PI;
     const maxCircleRadius = 165;
     function createColumn(group, location) {
+      let count = group.length;
       for (let i=0; i<count; i++) {
         const sprite = group[i];
         sprite.x = location;
@@ -646,6 +647,7 @@ module.exports = class DanceParty {
     }
 
     function createRow(group, location) {
+      let count = group.length;
       for (let i=0; i<count; i++) {
         const sprite = group[i];
         sprite.x = (i+1) * (400 / (count + 1));
@@ -655,6 +657,7 @@ module.exports = class DanceParty {
     }
 
     let createSquare = group => {
+      let count = group.length;
       const pct = this.p5_.constrain(count / 10, 0, 1);
       const radius = this.p5_.lerp(0, 100, pct);
       const size = Math.ceil(Math.sqrt(count));

--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -636,26 +636,44 @@ module.exports = class DanceParty {
     const maxY = 400 - 40;
     const radiansToDegrees = 180 / Math.PI;
     const maxCircleRadius = 165;
-    function createColumn(group, location) {
+
+    /**
+     * Sets the x & y positions of a group of sprites in order to arrange them
+     * in a vertical column.
+     * @param {array<sprite>} group - The group of sprites to arrange
+     * @param {int} xLocation - The xLocation to set for all sprites
+     */
+    function createColumn(group, xLocation) {
       let count = group.length;
       for (let i=0; i<count; i++) {
         const sprite = group[i];
-        sprite.x = location;
+        sprite.x = xLocation;
         sprite.y = (i+1) * (400 / (count + 1));
         sprite.rotation = 0;
       }
     }
 
-    function createRow(group, location) {
+    /**
+     * Sets the x & y positions of a group of sprites in order to arrange them
+     * in a horizontal row.
+     * @param {array<sprite>} group - The group of sprites to arrange
+     * @param {int} yLocation - The yLocation to set for all sprites
+     */
+    function createRow(group, yLocation) {
       let count = group.length;
       for (let i=0; i<count; i++) {
         const sprite = group[i];
         sprite.x = (i+1) * (400 / (count + 1));
-        sprite.y = location;
+        sprite.y = yLocation;
         sprite.rotation = 0;
       }
     }
 
+    /**
+     * Sets the x & y positions of a group of sprites in order to arrange them
+     * in a solid square.
+     * @param {array<sprite>} group - The group of sprites to arrange
+     */
     let createSquare = group => {
       let count = group.length;
       const pct = this.p5_.constrain(count / 10, 0, 1);
@@ -742,9 +760,13 @@ module.exports = class DanceParty {
       createSquare(group);
     } else if (format === "diamond") {
       createSquare(group);
+
+      // Tilt the square 45° to create a diamond.
       group.forEach((sprite, i) => {
         const x = sprite.x;
         const y = sprite.y;
+
+        // Math.<sin,cos> expects degrees in radians.
         sprite.x = (x - 200) * Math.cos(Math.PI/4) - (y - 200) * Math.sin(Math.PI/4) + 200;
         sprite.y = (x - 200) * Math.sin(Math.PI/4) + (y - 200) * Math.cos(Math.PI/4) + 200;
       });

--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -665,7 +665,7 @@ module.exports = class DanceParty {
         sprite.y = this.p5_.lerp(200 - radius, 200 + radius, row / (size - 1));
         sprite.rotation = 0;
       });
-    }
+    };
 
     if (format === "circle") {
       // Adjust radius of circle and size of the sprite according to number of

--- a/test/unit/groupTest.js
+++ b/test/unit/groupTest.js
@@ -258,7 +258,7 @@ test('LayoutSprites is safe to call with any layout on an empty group', async t 
     bpm: 120,
   });
 
-  ['circle', 'plus', 'x', 'grid', 'inner', 'row', 'column', 'border', 'random'].forEach(layout => {
+  ['circle', 'plus', 'x', 'grid', 'inner', 'diamond', 'top', 'row', 'bottom', 'left', 'column', 'right', 'border', 'random'].forEach(layout => {
     nativeAPI.layoutSprites('BEAR', layout);
   });
 


### PR DESCRIPTION
Adds 5 new layouts

## Left/right column
![image (9)](https://user-images.githubusercontent.com/8324574/69586468-855a7e00-0f97-11ea-95d6-eaafc56fadc9.png)

## Top/bottom row
![image (10)](https://user-images.githubusercontent.com/8324574/69586437-71af1780-0f97-11ea-8959-6a4a14ef35b5.png)

## Diamond
![image (11)](https://user-images.githubusercontent.com/8324574/69586433-6fe55400-0f97-11ea-9366-ce0ebfa05237.png)

### Diamond with non-square numbers of sprites
<img src="https://user-images.githubusercontent.com/8324574/69586438-72e04480-0f97-11ea-8fec-ac258fbc9853.png" width="300" />
<img src="https://user-images.githubusercontent.com/8324574/69586440-7378db00-0f97-11ea-8814-ccc5eb3dfbae.png" width="300" />
<img src="https://user-images.githubusercontent.com/8324574/69586445-74aa0800-0f97-11ea-863f-077b9cc4af34.png" width="300" />
