### PR TITLE
ignore non-dancer sprites for replay

### DIFF
--- a/src/replay.js
+++ b/src/replay.js
@@ -15,7 +15,7 @@ module.exports = {
 
     const frame = {bg, fg, context, palette};
 
-    const spritesToLog = p5.allSprites.slice(0, SPRITE_LIMIT);
+    const spritesToLog = p5.allSprites.filter(sprite => sprite.isDancer).slice(0, SPRITE_LIMIT);
     frame.sprites = spritesToLog.map((sprite) => ({
       animationFrame: sprite.animation && sprite.animation.getFrame(),
       animationLabel: sprite.getAnimationLabel(),

--- a/test/unit/replayTest.js
+++ b/test/unit/replayTest.js
@@ -6,11 +6,16 @@ class mockP5 {
     this.allSprites = [];
   }
 
-  createSprite() {
+  createDanceSprite() {
     this.allSprites.push({
       getAnimationLabel: () => {},
       mirrorX: () => {},
+      isDancer: true
     });
+  }
+
+  createEffectsSprite() {
+    this.allSprites.push({});
   }
 }
 
@@ -21,9 +26,14 @@ test('replay', t => {
   t.equal(replayLog.getLog().length, 1);
   t.equal(replayLog.getLog()[0].sprites.length, 0);
 
-  p5Inst.createSprite();
+  p5Inst.createDanceSprite();
   replayLog.logFrame({p5: p5Inst});
   t.equal(replayLog.getLog().length, 2);
+  t.equal(replayLog.getLog()[1].sprites.length, 1);
+
+  p5Inst.createEffectsSprite();
+  replayLog.logFrame({p5: p5Inst});
+  t.equal(replayLog.getLog().length, 3);
   t.equal(replayLog.getLog()[1].sprites.length, 1);
 
   t.end();

--- a/test/unit/replayTest.js
+++ b/test/unit/replayTest.js
@@ -47,12 +47,12 @@ test('Effects sprites are not added to replay log', t => {
   replayLog.logFrame({p5: p5Inst});
   t.equal(replayLog.getLog().length, 1);
   t.equal(replayLog.getLog()[0].sprites.length, 0);
-  
+
   p5Inst.createEffectsSprite();
   replayLog.logFrame({p5: p5Inst});
   t.equal(replayLog.getLog().length, 2);
   t.equal(replayLog.getLog()[1].sprites.length, 0);
-  
+
   replayLog.reset();
   t.end();
-})
+});

--- a/test/unit/replayTest.js
+++ b/test/unit/replayTest.js
@@ -14,12 +14,13 @@ class mockP5 {
     });
   }
 
+  // Some effects (ex. quads) create sprites which are not dancers
   createEffectsSprite() {
     this.allSprites.push({});
   }
 }
 
-test('replay', t => {
+test('Dance sprites are added to replay log', t => {
   const p5Inst = new mockP5();
 
   replayLog.logFrame({p5: p5Inst});
@@ -31,10 +32,27 @@ test('replay', t => {
   t.equal(replayLog.getLog().length, 2);
   t.equal(replayLog.getLog()[1].sprites.length, 1);
 
-  p5Inst.createEffectsSprite();
+  p5Inst.createDanceSprite();
   replayLog.logFrame({p5: p5Inst});
   t.equal(replayLog.getLog().length, 3);
-  t.equal(replayLog.getLog()[1].sprites.length, 1);
+  t.equal(replayLog.getLog()[2].sprites.length, 2);
 
+  replayLog.reset();
   t.end();
 });
+
+test('Effects sprites are not added to replay log', t => {
+  const p5Inst = new mockP5();
+
+  replayLog.logFrame({p5: p5Inst});
+  t.equal(replayLog.getLog().length, 1);
+  t.equal(replayLog.getLog()[0].sprites.length, 0);
+  
+  p5Inst.createEffectsSprite();
+  replayLog.logFrame({p5: p5Inst});
+  t.equal(replayLog.getLog().length, 2);
+  t.equal(replayLog.getLog()[1].sprites.length, 0);
+  
+  replayLog.reset();
+  t.end();
+})


### PR DESCRIPTION
See also https://github.com/code-dot-org/dance-party/pull/594
The quads background makes additional sprites for the vertices and edges, but which are not dancers. This adds filter logic to ignore those sprites for the replay log.