### PR TITLE
Bump @code-dot-org/p5.play to 1.3.14-cdo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2412,9 +2412,9 @@
       }
     },
     "@code-dot-org/p5": {
-      "version": "0.5.4-cdo.4",
-      "resolved": "https://registry.npmjs.org/@code-dot-org/p5/-/p5-0.5.4-cdo.4.tgz",
-      "integrity": "sha512-WtAJokLTOVg2H4GsboMRnR0jgXxFBbxiHimDo2yY88xzBNI9NugV8EA474IO8U7m6guo3FfM4LzilY6O51HDnw==",
+      "version": "0.5.4-cdo.6",
+      "resolved": "https://registry.npmjs.org/@code-dot-org/p5/-/p5-0.5.4-cdo.6.tgz",
+      "integrity": "sha512-qcrqnrMwIXvRc3kwI+t0LRrVa/GsondnIazbOrQuoVDvPZnCbf+VAD75+jJjcmaDS7Bqw+KlNlIX/WSmgDIY+w==",
       "dev": true,
       "requires": {
         "opentype.js": "^0.4.9",
@@ -2422,12 +2422,12 @@
       }
     },
     "@code-dot-org/p5.play": {
-      "version": "1.3.12-cdo",
-      "resolved": "https://registry.npmjs.org/@code-dot-org/p5.play/-/p5.play-1.3.12-cdo.tgz",
-      "integrity": "sha512-3zVTCLeOMowuZICzWF3OF9qY88j2Iq7q6h+NM6xvspecISi+veQ2JrO1FxXJL9wCIj75gJC1S3IKdYD66Bsk/w==",
+      "version": "1.3.14-cdo",
+      "resolved": "https://registry.npmjs.org/@code-dot-org/p5.play/-/p5.play-1.3.14-cdo.tgz",
+      "integrity": "sha512-flG1f0FQK73YrNBwyTECYmokARCnlLttCXoujZ5QX1vG3ex6YI0wc+V/vBV1s0g0gaEH3z9QLw3jeozJQAlR/w==",
       "dev": true,
       "requires": {
-        "@code-dot-org/p5": "0.5.4-cdo.4"
+        "@code-dot-org/p5": "0.5.4-cdo.6"
       }
     },
     "@mrmlnc/readdir-enhanced": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@babel/core": "^7.7.5",
     "@babel/polyfill": "^7.7.0",
     "@babel/preset-env": "^7.7.6",
-    "@code-dot-org/p5.play": "^1.3.12-cdo",
+    "@code-dot-org/p5.play": "^1.3.14-cdo",
     "babel-loader": "^8.0.6",
     "babelify": "^6.3.0",
     "canvas": "^1.6.13",


### PR DESCRIPTION
Bumps @code-dot-org/p5.play version ([see corresponding change in p5.play](https://github.com/code-dot-org/p5.play/pull/55)).

Once this has been merged, I'll publish a new version of dance-party to NPM.