### PR TITLE
Allow spiral to continue off screen

### DIFF
--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -158,11 +158,13 @@ module.exports = class DanceParty {
   async ensureSpritesAreLoaded(costumeNames = this.world.SPRITE_NAMES) {
     this.allSpritesLoaded = false;
     const animationData = await this.resourceLoader_.getAnimationData();
-    await this.loadExtraImages();
-    await Promise.all(costumeNames.map((costume) => {
+   
+    const promises = costumeNames.map((costume) => {
       const costumeData = animationData[costume.toLowerCase()];
       return this.loadCostumeAnimations(costume, costumeData);
-    }));
+    });
+    promises.push(this.loadExtraImages());
+    await Promise.all(promises);
     this.allSpritesLoaded = true;
   }
 

--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -718,16 +718,17 @@ module.exports = class DanceParty {
       const pct = this.p5_.constrain(count / 10, 0, 1);
       const scale = this.p5_.lerp(0.6, 0.3, pct * pct);
       const startAngle = -Math.PI / 2;
-      // The length of the spiral gets longer as we go from up from 5 towards 40
+      // The length of the spiral gets longer as we go from up from 5 towards 80
       // characters in the group.
-      const countConstrained = this.p5_.constrain(count, 5, 40);
-      // We go from 1 circle to 2 circles as the length of the spiral gets longer.
-      const cycles = this.p5_.lerp(1, 2, (countConstrained-5)/35);
+      const countConstrained = this.p5_.constrain(count, 5, 80);
+      // We go from 1 circle to 4 circles as the length of the spiral gets longer.
+      const cycles = this.p5_.lerp(1, 4, (countConstrained-5)/75);
       const deltaAngle =  cycles * 2 * Math.PI / count;
 
       group.forEach((sprite, i) => {
         const angle = deltaAngle * i + startAngle;
-        const radius = this.p5_.lerp(50, maxCircleRadius, i/count);
+        const maxRadius = this.p5_.lerp(0.75*maxCircleRadius, 2*maxCircleRadius, this.p5_.constrain(count / 80, 0, 1));
+        const radius = this.p5_.lerp(50, maxRadius, i/count);
         sprite.x = 200 + radius * Math.cos(angle);
         sprite.y = 200 + radius * Math.sin(angle);
         sprite.rotation = (angle - startAngle) * radiansToDegrees;

--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -158,7 +158,6 @@ module.exports = class DanceParty {
   async ensureSpritesAreLoaded(costumeNames = this.world.SPRITE_NAMES) {
     this.allSpritesLoaded = false;
     const animationData = await this.resourceLoader_.getAnimationData();
-   
     const promises = costumeNames.map((costume) => {
       const costumeData = animationData[costume.toLowerCase()];
       return this.loadCostumeAnimations(costume, costumeData);


### PR DESCRIPTION
This adjusts the spiral layout so that it can continue off the screen.

It also improves the asynchronous sprite loading so that the Higher Power background is loaded in parallel with the other sprites.

Follow-up to https://github.com/code-dot-org/dance-party/pull/621.

### before

https://user-images.githubusercontent.com/2205926/153532496-a6f40480-293a-4933-bf24-e21b3c038463.mov

### after

https://user-images.githubusercontent.com/2205926/153532480-3e494c0b-9f15-4fea-9dc5-46db9ad94479.mov


