### PR TITLE
Foreground effects in preview

### DIFF
--- a/src/Effects.js
+++ b/src/Effects.js
@@ -809,12 +809,9 @@ module.exports = class Effects {
           return;
         }
         for (let i = 0; i < 10; i++) {
-          const yMin = getInPreviewMode() ? 0 : -400;
-          const yMax = getInPreviewMode() ? 400 : 0;
-
           this.tacos.push({
             x: randomNumber(20, 380),
-            y: randomNumber(yMin, yMax),
+            y: this.getPreviewCustomizations().y,
             rot: randomNumber(0, 359),
             speed: 3,
             size: 5,
@@ -825,9 +822,7 @@ module.exports = class Effects {
         drawTaco(this.image.drawingContext);
       },
       draw: function (context) {
-        const centroid = getInPreviewMode() ?
-          6500 :
-          context.centroid;
+        const centroid = this.getPreviewCustomizations().getCentroid(context);
         for (let i = 0; i < this.tacos.length; i++) {
           p5.push();
           const taco = this.tacos[i];
@@ -848,7 +843,18 @@ module.exports = class Effects {
       },
       reset: function () {
         this.tacos = [];
-      }
+      },
+      getPreviewCustomizations: function () {
+        return getInPreviewMode() ?
+          {
+            y: randomNumber(0, 400),
+            getCentroid: () => 6500,
+          } :
+          {
+            y: randomNumber(-400, 0),
+            getCentroid: context => context.centroid,
+          };
+      },
     };
 
     this.pineapples = {

--- a/src/Effects.js
+++ b/src/Effects.js
@@ -26,6 +26,8 @@ module.exports = class Effects {
     this.extraImages = extraImages;
     this.blend = blend || p5.BLEND;
     this.currentPalette = currentPalette;
+    this.inPreviewMode = false;
+    const getInPreviewMode = this.getInPreviewMode.bind(this);
 
     function randomNumber(min, max) {
       return Math.round(p5.random(min, max));
@@ -860,7 +862,7 @@ module.exports = class Effects {
           const pineapple = this.pineappleList[i];
           p5.translate(pineapple.x, pineapple.y);
           p5.rotate(pineapple.rot);
-          p5.scale(pineapple.life / 20 / (7 * p5.pixelDensity()));
+          p5.scale(this.inPreviewMode() ? 2 / (7 * p5.pixelDensity()) : pineapple.life / 20 / (7 * p5.pixelDensity()));
           p5.drawingContext.drawImage(this.image.elt, -35, -65);
           pineapple.life--;
           if (pineapple.life < 0) {
@@ -871,6 +873,7 @@ module.exports = class Effects {
           p5.pop();
         }
       },
+      inPreviewMode: getInPreviewMode,
     };
 
     this.splatter = {
@@ -1310,7 +1313,7 @@ module.exports = class Effects {
           p5.push();
           p5.translate(poop.x, poop.y);
           p5.rotate(poop.rot);
-          p5.scale(poop.life / 20);
+          p5.scale(this.inPreviewMode() ? 2 : poop.life / 20);
           drawPoop(p5._renderer.drawingContext);
           poop.life--;
           if (poop.life < 0) {
@@ -1321,6 +1324,7 @@ module.exports = class Effects {
           p5.pop();
         }
       },
+      inPreviewMode: getInPreviewMode,
     };
 
     this.hearts_red = {
@@ -1657,6 +1661,10 @@ module.exports = class Effects {
       },
     };
 
+    // doesn't quite reset between runs
+    // state of preview becomes starting point for next run
+    // i think this is true for some backgrounds (eg, rain)
+    // as well, though.
     this.exploding_stars = {
       stars: [],
       resetStars: function () {
@@ -1665,8 +1673,8 @@ module.exports = class Effects {
           let velocity = p5.random(4, 12);
           this.stars.push({
             color: randomColor(255, 255, 100),
-            x: 200,
-            y: 200,
+            x: this.inPreviewMode() ? p5.random(0, 400) : 200,
+            y: this.inPreviewMode() ? p5.random(0, 400) : 200,
             dx: velocity * p5.cos(theta),
             dy: velocity * p5.sin(theta),
           });
@@ -1688,6 +1696,7 @@ module.exports = class Effects {
           star => star.x > -10 && star.x < 410 && star.y > -10 && star.y < 410
         );
       },
+      inPreviewMode: getInPreviewMode
     };
 
     this.galaxy = {
@@ -2133,6 +2142,14 @@ module.exports = class Effects {
         }
       },
     };
+  }
+
+  setInPreviewMode(inPreviewMode) {
+    this.inPreviewMode = inPreviewMode;
+  }
+
+  getInPreviewMode() {
+    return this.inPreviewMode;
   }
 
   randomForegroundEffect() {

--- a/src/Effects.js
+++ b/src/Effects.js
@@ -1654,57 +1654,33 @@ module.exports = class Effects {
     this.bubbles = {
       bubble: [],
       draw: function () {
-        if (getInPreviewMode()) {
-          for (let i = 0; i < 200; i++) {
-            let bubble = {
-              x: p5.random(-100, 400),
-              y: p5.random(-100, 400), // changed
-              velocityX: p5.random(-2, 2),
-              size: p5.random(6, 12, 18),
-              color: randomColor(100, 50, 0.25),
-            };
-            this.bubble.push(bubble);
-          }
-
-          p5.noStroke();
-          this.bubble.forEach(function (bubble) {
-            p5.push();
-            p5.fill(bubble.color);
-            p5.translate(bubble.x, bubble.y);
-            p5.ellipse(0, 0, bubble.size, bubble.size);
-            let fallSpeed = p5.map(bubble.size, 6, 12, 1, 3);
-            bubble.y -= fallSpeed;
-            bubble.x += bubble.velocityX;
-            p5.pop();
-          });
-          this.bubble = this.bubble.filter(function (bubble) {
-            return bubble.y > 0;
-          });
-
-        } else {
+        const bubblesToDraw = getInPreviewMode() ? 200 : 1;
+        for (let i = 0; i < bubblesToDraw; i++) {
+          const y = getInPreviewMode() ? p5.random(-100, 400) : 410;
           let bubble = {
             x: p5.random(-100, 400),
-            y: 410,
+            y: y,
             velocityX: p5.random(-2, 2),
             size: p5.random(6, 12, 18),
             color: randomColor(100, 50, 0.25),
           };
           this.bubble.push(bubble);
-          p5.noStroke();
-          this.bubble.forEach(function (bubble) {
-            p5.push();
-            p5.fill(bubble.color);
-            p5.translate(bubble.x, bubble.y);
-            p5.ellipse(0, 0, bubble.size, bubble.size);
-            let fallSpeed = p5.map(bubble.size, 6, 12, 1, 3);
-            bubble.y -= fallSpeed;
-            bubble.x += bubble.velocityX;
-            p5.pop();
-          });
-          this.bubble = this.bubble.filter(function (bubble) {
-            return bubble.y > 0;
-          });
         }
+
+        p5.noStroke();
+        this.bubble.forEach(function (bubble) {
+          p5.push();
+          p5.fill(bubble.color);
+          p5.translate(bubble.x, bubble.y);
+          p5.ellipse(0, 0, bubble.size, bubble.size);
+          let fallSpeed = p5.map(bubble.size, 6, 12, 1, 3);
+          bubble.y -= fallSpeed;
+          bubble.x += bubble.velocityX;
+          p5.pop();
+        });
+        this.bubble = this.bubble.filter(function (bubble) {
+          return bubble.y > 0;
+        });
       },
       reset: function () {
         this.bubble = [];
@@ -1910,69 +1886,40 @@ module.exports = class Effects {
     this.confetti = {
       confetti: [],
       draw: function () {
-        if (getInPreviewMode()) {
-          for (let i = 0; i < 200; i++) {
-            let confetti = {
-              x: p5.random(-100, 400),
-              y: p5.random(-100, 400), // changed
-              velocityX: p5.random(-2, 2),
-              size: p5.random(6, 12, 18),
-              // https://github.com/Automattic/node-canvas/issues/702
-              // Bug with node-canvas prevents scaling with a value of 0, so spin initializes to 1
-              spin: 90, //changed
-              color: randomColor(255, 255, 100),
-            };
-
-            this.confetti.push(confetti);
-          }
-
-          p5.noStroke();
-          this.confetti.forEach(function (confetti) {
-            p5.push();
-            p5.fill(confetti.color);
-            p5.translate(confetti.x, confetti.y);
-            const scaleX = p5.sin(confetti.spin);
-            p5.scale(scaleX, 1);
-            confetti.spin += 20;
-            p5.rect(0, 0, 4, confetti.size);
-            let fallSpeed = p5.map(confetti.size, 6, 12, 1, 3);
-            confetti.y += fallSpeed;
-            confetti.x += confetti.velocityX;
-            p5.pop();
-          });
-          this.confetti = this.confetti.filter(function (confetti) {
-            return confetti.y < 425;
-          });
-        } else {
+        const bubblesToDraw = getInPreviewMode() ? 200 : 1;
+        for (let i = 0; i < bubblesToDraw; i++) {
+          const spin = getInPreviewMode() ? p5.random(1, 80) : 1;
           let confetti = {
             x: p5.random(-100, 400),
-            y: -10,
+            y: p5.random(-100, 400), // changed
             velocityX: p5.random(-2, 2),
             size: p5.random(6, 12, 18),
             // https://github.com/Automattic/node-canvas/issues/702
             // Bug with node-canvas prevents scaling with a value of 0, so spin initializes to 1
-            spin: 1,
+            spin: spin, //changed
             color: randomColor(255, 255, 100),
           };
+
           this.confetti.push(confetti);
-          p5.noStroke();
-          this.confetti.forEach(function (confetti) {
-            p5.push();
-            p5.fill(confetti.color);
-            p5.translate(confetti.x, confetti.y);
-            const scaleX = p5.sin(confetti.spin);
-            p5.scale(scaleX, 1);
-            confetti.spin += 20;
-            p5.rect(0, 0, 4, confetti.size);
-            let fallSpeed = p5.map(confetti.size, 6, 12, 1, 3);
-            confetti.y += fallSpeed;
-            confetti.x += confetti.velocityX;
-            p5.pop();
-          });
-          this.confetti = this.confetti.filter(function (confetti) {
-            return confetti.y < 425;
-          });
         }
+
+        p5.noStroke();
+        this.confetti.forEach(function (confetti) {
+          p5.push();
+          p5.fill(confetti.color);
+          p5.translate(confetti.x, confetti.y);
+          const scaleX = p5.sin(confetti.spin);
+          p5.scale(scaleX, 1);
+          confetti.spin += 20;
+          p5.rect(0, 0, 4, confetti.size);
+          let fallSpeed = p5.map(confetti.size, 6, 12, 1, 3);
+          confetti.y += fallSpeed;
+          confetti.x += confetti.velocityX;
+          p5.pop();
+        });
+        this.confetti = this.confetti.filter(function (confetti) {
+          return confetti.y < 425;
+        });
       },
       reset: function () {
         this.confetti = [];
@@ -2035,45 +1982,23 @@ module.exports = class Effects {
         drawMusicNote(this.image.drawingContext);
       },
       draw: function (context) {
-        if (getInPreviewMode()) {
-          // changed
-          const centroid = 6500;
-          for (let i = 0; i < this.notes.length; i++) {
-            p5.push();
-            const notes = this.notes[i];
-            let scale = p5.map(centroid, 5000, 8000, 0, notes.size);
-            scale = p5.constrain(scale, 0, 3);
-            p5.translate(notes.x, notes.y);
-            p5.rotate(notes.rot);
-            p5.scale(scale / (4 * p5.pixelDensity()));
-            p5.drawingContext.drawImage(this.image.elt, 0, 0);
-            notes.y += notes.speed;
-            notes.rot++;
-            if (notes.y > 410) {
-              notes.x = randomNumber(10, 390);
-              notes.y = -50;
-            }
-            p5.pop();
+        const centroid = getInPreviewMode() ? 6500 : context.centroid;
+        for (let i = 0; i < this.notes.length; i++) {
+          p5.push();
+          const notes = this.notes[i];
+          let scale = p5.map(centroid, 5000, 8000, 0, notes.size);
+          scale = p5.constrain(scale, 0, 3);
+          p5.translate(notes.x, notes.y);
+          p5.rotate(notes.rot);
+          p5.scale(scale / (4 * p5.pixelDensity()));
+          p5.drawingContext.drawImage(this.image.elt, 0, 0);
+          notes.y += notes.speed;
+          notes.rot++;
+          if (notes.y > 410) {
+            notes.x = randomNumber(10, 390);
+            notes.y = -50;
           }
-        } else {
-          const centroid = context.centroid;
-          for (let i = 0; i < this.notes.length; i++) {
-            p5.push();
-            const notes = this.notes[i];
-            let scale = p5.map(centroid, 5000, 8000, 0, notes.size);
-            scale = p5.constrain(scale, 0, 3);
-            p5.translate(notes.x, notes.y);
-            p5.rotate(notes.rot);
-            p5.scale(scale / (4 * p5.pixelDensity()));
-            p5.drawingContext.drawImage(this.image.elt, 0, 0);
-            notes.y += notes.speed;
-            notes.rot++;
-            if (notes.y > 410) {
-              notes.x = randomNumber(10, 390);
-              notes.y = -50;
-            }
-            p5.pop();
-          }
+          p5.pop();
         }
       },
       reset: function () {
@@ -2246,7 +2171,6 @@ module.exports = class Effects {
       },
     };
 
-    // preview not working
     this.emojis = {
       emojiList: [],
       emojiTypes: [],
@@ -2283,27 +2207,10 @@ module.exports = class Effects {
           for (let i = 0; i < 12; i++) {
             this.emojiList.push({
               x: randomNumber(0, 350),
-              y: randomNumber(0, 350), // changed
+              y: randomNumber(0, 350),
               size: randomNumber(50, 90),
               image: this.emojiTypes[randomNumber(0, 4)],
             });
-          }
-          for (let i = 0; i < this.emojiList.length; ++i) {
-            const emoji = this.emojiList[i];
-            emoji.y += p5.pow(emoji.size, 0.25); // emoji falls at a rate fourth root to its size
-            if (emoji.y > p5.height * 1.2) {
-              // if the emoji has fallen past 120% of the screen
-              this.emojiList.splice(i, 1);
-            }
-            p5.push();
-            p5.drawingContext.drawImage(
-              emoji.image.elt,
-              emoji.x,
-              emoji.y,
-              emoji.size,
-              emoji.size
-            );
-            p5.pop();
           }
         } else {
           if (p5.frameCount % 10 === 0) {
@@ -2315,25 +2222,26 @@ module.exports = class Effects {
               image: this.emojiTypes[randomNumber(0, 4)],
             });
           }
-          for (let i = 0; i < this.emojiList.length; ++i) {
-            const emoji = this.emojiList[i];
-            emoji.y += p5.pow(emoji.size, 0.25); // emoji falls at a rate fourth root to its size
-            if (emoji.y > p5.height * 1.2) {
-              // if the emoji has fallen past 120% of the screen
-              this.emojiList.splice(i, 1);
-            }
-            p5.push();
-            p5.drawingContext.drawImage(
-              emoji.image.elt,
-              emoji.x,
-              emoji.y,
-              emoji.size,
-              emoji.size
-            );
-            p5.pop();
-          }
         }
-      },
+
+        for (let i = 0; i < this.emojiList.length; ++i) {
+          const emoji = this.emojiList[i];
+          emoji.y += p5.pow(emoji.size, 0.25); // emoji falls at a rate fourth root to its size
+          if (emoji.y > p5.height * 1.2) {
+            // if the emoji has fallen past 120% of the screen
+            this.emojiList.splice(i, 1);
+          }
+          p5.push();
+          p5.drawingContext.drawImage(
+            emoji.image.elt,
+            emoji.x,
+            emoji.y,
+            emoji.size,
+            emoji.size
+          );
+          p5.pop();
+        }
+        },
       reset: function () {
         this.emojiList = [];
       }

--- a/src/Effects.js
+++ b/src/Effects.js
@@ -1904,7 +1904,7 @@ module.exports = class Effects {
           const spin = this.getPreviewCustomizations().spin;
           let confetti = {
             x: p5.random(-100, 400),
-            y: p5.random(-100, 400), // changed
+            y: this.getPreviewCustomizations().y,
             velocityX: p5.random(-2, 2),
             size: p5.random(6, 12, 18),
             // https://github.com/Automattic/node-canvas/issues/702
@@ -1939,8 +1939,8 @@ module.exports = class Effects {
       },
       getPreviewCustomizations: function () {
         return getInPreviewMode() ?
-          {numConfettiToDraw: 200, spin: p5.random(1, 80)} :
-          {numConfettiToDraw: 1, spin: 1};
+          {numConfettiToDraw: 200, spin: p5.random(1, 80), y: p5.random(-100, 400)} :
+          {numConfettiToDraw: 1, spin: 1, y: -10};
       }
     };
 

--- a/src/Effects.js
+++ b/src/Effects.js
@@ -805,9 +805,9 @@ module.exports = class Effects {
     this.raining_tacos = {
       tacos: [],
       init: function () {
-        if (this.tacos.length) {
-          return;
-        }
+        // if (this.tacos.length) {
+        //   return;
+        // }
         for (let i = 0; i < 10; i++) {
           this.tacos.push({
             x: randomNumber(20, 380),
@@ -843,6 +843,7 @@ module.exports = class Effects {
       },
       reset: function () {
         this.tacos = [];
+        this.init();
       },
       getPreviewCustomizations: function () {
         return getInPreviewMode() ?
@@ -879,11 +880,7 @@ module.exports = class Effects {
         for (let i = 0; i < this.pineappleList.length; i++) {
           p5.push();
           const pineapple = this.pineappleList[i];
-
-          // added. randomNumber(10, 120) copied from life reset below
-          const scale = getInPreviewMode() ?
-            randomNumber(10, 120) / 20 / (7 * p5.pixelDensity()) :
-            pineapple.life / 20 / (7 * p5.pixelDensity());
+          const scale = this.getPreviewCustomizations().getScale(pineapple);
 
           p5.translate(pineapple.x, pineapple.y);
           p5.rotate(pineapple.rot);
@@ -900,6 +897,11 @@ module.exports = class Effects {
       },
       reset: function () {
         this.pineappleList = [];
+      },
+      getPreviewCustomizations: function () {
+        return getInPreviewMode() ?
+          {getScale: () => randomNumber(10, 120) / 20 / (7 * p5.pixelDensity())} :
+          {getScale: pineapple => pineapple.life / 20 / (7 * p5.pixelDensity())};
       },
     };
 
@@ -1340,9 +1342,7 @@ module.exports = class Effects {
       },
       draw: function () {
         for (const poop of this.poopList) {
-          const scale = getInPreviewMode() ?
-            randomNumber(10, 120) / 20 :
-            poop.life / 20;
+          const scale = this.getPreviewCustomizations().getScale(poop);
 
           p5.push();
           p5.translate(poop.x, poop.y);
@@ -1360,6 +1360,11 @@ module.exports = class Effects {
       },
       reset: function () {
         this.poopList = [];
+      },
+      getPreviewCustomizations: function () {
+        return getInPreviewMode() ?
+          {getScale: () => randomNumber(10, 120) / 20} :
+          {getScale: poop => poop.life / 20};
       },
     };
 
@@ -1449,12 +1454,11 @@ module.exports = class Effects {
           return;
         }
 
-        const yMin = getInPreviewMode() ? 0 : 400;
-        const yMax = getInPreviewMode() ? 400 : 800;
+        // check if y is varying
         for (let i = 0; i < 15; i++) {
           this.rainbows.push({
             x: randomNumber(10, 390),
-            y: randomNumber(yMin, yMax),
+            y: this.getPreviewCustomizations().y,
             rot: randomNumber(0, 359),
             speed: 2,
             size: randomNumber(1.5, 3),
@@ -1465,9 +1469,7 @@ module.exports = class Effects {
         drawRainbow(this.image.drawingContext);
       },
       draw: function (context) {
-        const centroid = getInPreviewMode() ?
-          6500 :
-          context.centroid;
+        const centroid = this.getPreviewCustomizations().getCentroid(context);
 
         for (let i = 0; i < this.rainbows.length; i++) {
           p5.push();
@@ -1487,7 +1489,18 @@ module.exports = class Effects {
       },
       reset: function () {
         this.rainbows = [];
-      }
+      },
+      getPreviewCustomizations: function () {
+        return getInPreviewMode() ?
+          {
+            y: randomNumber(0, 400),
+            getCentroid: () => 6500,
+          } :
+          {
+            y: randomNumber(400, 800),
+            getCentroid: context => context.centroid,
+          };
+      },
     };
 
     this.snowflakes = {
@@ -1660,12 +1673,11 @@ module.exports = class Effects {
     this.bubbles = {
       bubble: [],
       draw: function () {
-        const bubblesToDraw = getInPreviewMode() ? 200 : 1;
-        for (let i = 0; i < bubblesToDraw; i++) {
-          const y = getInPreviewMode() ? p5.random(-100, 400) : 410;
+        const numBubblesToDraw = this.getPreviewCustomizations().numBubblesToDraw;
+        for (let i = 0; i < numBubblesToDraw; i++) {
           let bubble = {
             x: p5.random(-100, 400),
-            y: y,
+            y: this.getPreviewCustomizations().y,
             velocityX: p5.random(-2, 2),
             size: p5.random(6, 12, 18),
             color: randomColor(100, 50, 0.25),
@@ -1691,6 +1703,11 @@ module.exports = class Effects {
       reset: function () {
         this.bubble = [];
       },
+      getPreviewCustomizations: function () {
+        return getInPreviewMode() ?
+          {numBubblesToDraw: 200, y: p5.random(-100, 400)} :
+          {numBubblesToDraw: 1, y: 410};
+      }
     };
 
     this.stars = {
@@ -1734,16 +1751,10 @@ module.exports = class Effects {
           let theta = p5.random(0, 360);
           let velocity = p5.random(4, 12);
 
-          const x = getInPreviewMode() ?
-            randomNumber(0, 400) :
-            200;
-          const y = getInPreviewMode() ?
-            randomNumber(0, 400) :
-            200;
           this.stars.push({
             color: randomColor(255, 255, 100),
-            x: x,
-            y: y,
+            x: this.getPreviewCustomizations().x,
+            y: this.getPreviewCustomizations().y,
             dx: velocity * p5.cos(theta),
             dy: velocity * p5.sin(theta),
           });
@@ -1765,6 +1776,11 @@ module.exports = class Effects {
           star => star.x > -10 && star.x < 410 && star.y > -10 && star.y < 410
         );
       },
+      getPreviewCustomizations: function () {
+        return getInPreviewMode() ?
+          {x: randomNumber(0, 400), y: randomNumber(0, 400)} :
+          {x: 200, y: 200};
+      }
     };
 
     this.galaxy = {
@@ -1822,9 +1838,7 @@ module.exports = class Effects {
         drawPizza(this.image.drawingContext);
       },
       draw: function (context) {
-        const centroid = getInPreviewMode() ?
-          6500 :
-          context.centroid;
+        const centroid = this.getPreviewCustomizations().getCentroid(context);
         for (let i = 0; i < this.pizza.length; i++) {
           p5.push();
           const pizza = this.pizza[i];
@@ -1842,6 +1856,11 @@ module.exports = class Effects {
           }
           p5.pop();
         }
+      },
+      getPreviewCustomizations: function () {
+        return getInPreviewMode() ?
+          {getCentroid: () => 6500} :
+          {getCentroid: context => context.centroid};
       },
     };
 
@@ -1865,9 +1884,7 @@ module.exports = class Effects {
         drawSmiley(this.image.drawingContext, 0.8);
       },
       draw: function (context) {
-        const centroid = getInPreviewMode() ?
-          6500 :
-          context.centroid;
+        const centroid = this.getPreviewCustomizations().getCentroid(context);
 
         for (let i = 0; i < this.smiles.length; i++) {
           p5.push();
@@ -1887,14 +1904,19 @@ module.exports = class Effects {
           p5.pop();
         }
       },
+      getPreviewCustomizations: function () {
+        return getInPreviewMode() ?
+          {getCentroid: () => 6500} :
+          {getCentroid: context => context.centroid};
+      },
     };
 
     this.confetti = {
       confetti: [],
       draw: function () {
-        const bubblesToDraw = getInPreviewMode() ? 200 : 1;
-        for (let i = 0; i < bubblesToDraw; i++) {
-          const spin = getInPreviewMode() ? p5.random(1, 80) : 1;
+        const numConfettiToDraw = this.getPreviewCustomizations().numConfettiToDraw;
+        for (let i = 0; i < numConfettiToDraw; i++) {
+          const spin = this.getPreviewCustomizations().spin;
           let confetti = {
             x: p5.random(-100, 400),
             y: p5.random(-100, 400), // changed
@@ -1902,7 +1924,7 @@ module.exports = class Effects {
             size: p5.random(6, 12, 18),
             // https://github.com/Automattic/node-canvas/issues/702
             // Bug with node-canvas prevents scaling with a value of 0, so spin initializes to 1
-            spin: spin, //changed
+            spin: spin,
             color: randomColor(255, 255, 100),
           };
 
@@ -1930,6 +1952,11 @@ module.exports = class Effects {
       reset: function () {
         this.confetti = [];
       },
+      getPreviewCustomizations: function () {
+        return getInPreviewMode() ?
+          {numConfettiToDraw: 200, spin: p5.random(1, 80)} :
+          {numConfettiToDraw: 1, spin: 1};
+      }
     };
 
     this.growing_stars = {
@@ -1969,15 +1996,13 @@ module.exports = class Effects {
     this.music_notes = {
       notes: [],
       init: function () {
-        const yMax = getInPreviewMode() ? 390 : 0;
-        const yMin = getInPreviewMode() ? 0 : -400;
         if (this.notes.length) {
           return;
         }
         for (let i = 0; i < 20; i++) {
           this.notes.push({
             x: randomNumber(10, 390),
-            y: randomNumber(yMin, yMax),
+            y: this.getPreviewCustomizations().y,
             rot: randomNumber(0, 359),
             speed: 2,
             size: randomNumber(1.5, 3),
@@ -1988,7 +2013,7 @@ module.exports = class Effects {
         drawMusicNote(this.image.drawingContext);
       },
       draw: function (context) {
-        const centroid = getInPreviewMode() ? 6500 : context.centroid;
+        const centroid = this.getPreviewCustomizations().getCentroid(context);
         for (let i = 0; i < this.notes.length; i++) {
           p5.push();
           const notes = this.notes[i];
@@ -2009,7 +2034,12 @@ module.exports = class Effects {
       },
       reset: function () {
         this.notes = [];
-      }
+      },
+      getPreviewCustomizations: function () {
+        return getInPreviewMode() ?
+          {y: randomNumber(0, 390), getCentroid: () => 6500} :
+          {y: randomNumber (-400, 0), getCentroid: context => context.centroid};
+      },
     };
 
     // to do
@@ -2209,26 +2239,7 @@ module.exports = class Effects {
       },
 
       draw: function () {
-        if (getInPreviewMode()) {
-          for (let i = 0; i < 12; i++) {
-            this.emojiList.push({
-              x: randomNumber(0, 350),
-              y: randomNumber(0, 350),
-              size: randomNumber(50, 90),
-              image: this.emojiTypes[randomNumber(0, 4)],
-            });
-          }
-        } else {
-          if (p5.frameCount % 10 === 0) {
-            // generate new emoji every 10 frames
-            this.emojiList.push({
-              x: randomNumber(0, 350),
-              y: -50,
-              size: randomNumber(50, 90),
-              image: this.emojiTypes[randomNumber(0, 4)],
-            });
-          }
-        }
+        this.getPreviewCustomizations().addEmojis();
 
         for (let i = 0; i < this.emojiList.length; ++i) {
           const emoji = this.emojiList[i];
@@ -2247,10 +2258,38 @@ module.exports = class Effects {
           );
           p5.pop();
         }
-        },
+      },
       reset: function () {
         this.emojiList = [];
-      }
+      },
+      getPreviewCustomizations: function () {
+        if (getInPreviewMode()) {
+          const addEmojisPreview = () => {
+            for (let i = 0; i < 12; i++) {
+              this.emojiList.push({
+                x: randomNumber(0, 350),
+                y: randomNumber(0, 350),
+                size: randomNumber(50, 90),
+                image: this.emojiTypes[randomNumber(0, 4)],
+              });
+            }
+          };
+          return {addEmojis: addEmojisPreview};
+        } else {
+          const addEmojisDefault = () => {
+            if (p5.frameCount % 10 === 0) {
+              // generate new emoji every 10 frames
+              this.emojiList.push({
+                x: randomNumber(0, 350),
+                y: -50,
+                size: randomNumber(50, 90),
+                image: this.emojiTypes[randomNumber(0, 4)],
+              });
+            }
+          };
+          return {addEmojis: addEmojisDefault};
+        }
+      },
     };
   }
 

--- a/src/Effects.js
+++ b/src/Effects.js
@@ -1317,7 +1317,6 @@ module.exports = class Effects {
       },
     };
 
-    // hitting reset removes poops from screen
     this.smiling_poop = {
       poopList: [],
       init: function () {
@@ -1978,7 +1977,6 @@ module.exports = class Effects {
       },
     };
 
-    // reset with no notes on screen not previewing correctly :/
     this.music_notes = {
       notes: [],
       init: function () {
@@ -2122,7 +2120,6 @@ module.exports = class Effects {
           this.crayons[this.current_drip].startFrame = p5.frameCount;
         }
       },
-      // buggy, maybe skip advance drawing in preview?
       getPreviewCustomizations: function () {
         return getInPreviewMode() ?
           {getRectHeight: () => p5.random(30, 200)} :

--- a/src/Effects.js
+++ b/src/Effects.js
@@ -688,6 +688,7 @@ module.exports = class Effects {
       },
     };
 
+    // looks good in production
     this.rain = {
       drops: [],
       init: function () {
@@ -799,6 +800,8 @@ module.exports = class Effects {
       },
     };
 
+    // reset clicked with no tacos on the screen
+    // doesn't preview any tacos
     this.raining_tacos = {
       tacos: [],
       init: function () {
@@ -806,9 +809,12 @@ module.exports = class Effects {
           return;
         }
         for (let i = 0; i < 10; i++) {
+          const yMin = getInPreviewMode() ? 0 : -400;
+          const yMax = getInPreviewMode() ? 400 : 0;
+
           this.tacos.push({
             x: randomNumber(20, 380),
-            y: randomNumber(-400, 0),
+            y: randomNumber(yMin, yMax),
             rot: randomNumber(0, 359),
             speed: 3,
             size: 5,
@@ -819,7 +825,9 @@ module.exports = class Effects {
         drawTaco(this.image.drawingContext);
       },
       draw: function (context) {
-        const centroid = context.centroid;
+        const centroid = getInPreviewMode() ?
+          6500 :
+          context.centroid;
         for (let i = 0; i < this.tacos.length; i++) {
           p5.push();
           const taco = this.tacos[i];
@@ -838,6 +846,9 @@ module.exports = class Effects {
           p5.pop();
         }
       },
+      reset: function () {
+        this.tacos = [];
+      }
     };
 
     this.pineapples = {
@@ -862,9 +873,15 @@ module.exports = class Effects {
         for (let i = 0; i < this.pineappleList.length; i++) {
           p5.push();
           const pineapple = this.pineappleList[i];
+
+          // added. randomNumber(10, 120) copied from life reset below
+          const scale = getInPreviewMode() ?
+            randomNumber(10, 120) / 20 / (7 * p5.pixelDensity()) :
+            pineapple.life / 20 / (7 * p5.pixelDensity());
+
           p5.translate(pineapple.x, pineapple.y);
           p5.rotate(pineapple.rot);
-          p5.scale(pineapple.life / 20 / (7 * p5.pixelDensity()));
+          p5.scale(scale); // changed
           p5.drawingContext.drawImage(this.image.elt, -35, -65);
           pineapple.life--;
           if (pineapple.life < 0) {
@@ -986,6 +1003,7 @@ module.exports = class Effects {
       },
     };
 
+    // looks ok?
     this.spotlight = {
       x: 200,
       y: 200,
@@ -1130,6 +1148,7 @@ module.exports = class Effects {
       },
     };
 
+    // looks good?
     this.color_lights = {
       lights: [],
       newLight: function (x, arc, offset) {
@@ -1297,6 +1316,7 @@ module.exports = class Effects {
       },
     };
 
+    // hitting reset removes poops from screen
     this.smiling_poop = {
       poopList: [],
       init: function () {
@@ -1314,10 +1334,14 @@ module.exports = class Effects {
       },
       draw: function () {
         for (const poop of this.poopList) {
+          const scale = getInPreviewMode() ?
+            randomNumber(10, 120) / 20 :
+            poop.life / 20;
+
           p5.push();
           p5.translate(poop.x, poop.y);
           p5.rotate(poop.rot);
-          p5.scale(poop.life / 20);
+          p5.scale(scale);
           drawPoop(p5._renderer.drawingContext);
           poop.life--;
           if (poop.life < 0) {
@@ -1333,6 +1357,7 @@ module.exports = class Effects {
       },
     };
 
+    // seems fine as is in production (doesn't reset though)
     this.hearts_red = {
       heartList: [],
       init: function () {
@@ -1370,6 +1395,7 @@ module.exports = class Effects {
       }
     };
 
+    // seems fine as is in production (doesn't reset though)
     this.hearts_colorful = {
       heartList: [],
       init: function () {
@@ -1408,16 +1434,21 @@ module.exports = class Effects {
       },
     };
 
+    // init happens on setting of foreground
+    // reset happens on reset() (before each run)?
     this.floating_rainbows = {
       rainbows: [],
       init: function () {
         if (this.rainbows.length) {
           return;
         }
+
+        const yMin = getInPreviewMode() ? 0 : 400;
+        const yMax = getInPreviewMode() ? 400 : 800;
         for (let i = 0; i < 15; i++) {
           this.rainbows.push({
             x: randomNumber(10, 390),
-            y: randomNumber(400, 800),
+            y: randomNumber(yMin, yMax),
             rot: randomNumber(0, 359),
             speed: 2,
             size: randomNumber(1.5, 3),
@@ -1428,7 +1459,10 @@ module.exports = class Effects {
         drawRainbow(this.image.drawingContext);
       },
       draw: function (context) {
-        const centroid = context.centroid;
+        const centroid = getInPreviewMode() ?
+          6500 :
+          context.centroid;
+
         for (let i = 0; i < this.rainbows.length; i++) {
           p5.push();
           const rainbows = this.rainbows[i];
@@ -1445,6 +1479,9 @@ module.exports = class Effects {
           p5.pop();
         }
       },
+      reset: function () {
+        this.rainbows = [];
+      }
     };
 
     this.snowflakes = {
@@ -1618,10 +1655,10 @@ module.exports = class Effects {
       bubble: [],
       draw: function () {
         if (getInPreviewMode()) {
-          for (let i = 1; i < 200; i++) {
+          for (let i = 0; i < 200; i++) {
             let bubble = {
               x: p5.random(-100, 400),
-              y: p5.random(-100, 400),
+              y: p5.random(-100, 400), // changed
               velocityX: p5.random(-2, 2),
               size: p5.random(6, 12, 18),
               color: randomColor(100, 50, 0.25),
@@ -1630,7 +1667,6 @@ module.exports = class Effects {
           }
 
           p5.noStroke();
-
           this.bubble.forEach(function (bubble) {
             p5.push();
             p5.fill(bubble.color);
@@ -1646,8 +1682,6 @@ module.exports = class Effects {
           });
 
         } else {
-          // reset here?
-          // prob don't want to...
           let bubble = {
             x: p5.random(-100, 400),
             y: 410,
@@ -1708,10 +1742,8 @@ module.exports = class Effects {
       },
     };
 
-    // doesn't quite reset between runs
-    // state of preview becomes starting point for next run
-    // i think this is true for some backgrounds (eg, rain)
-    // as well, though.
+    // reset button is putting all the stars in the middle
+    // instead of spreading out
     this.exploding_stars = {
       stars: [],
       reset: function () {
@@ -1719,10 +1751,17 @@ module.exports = class Effects {
         for (let i = 0; i < 100; i++) {
           let theta = p5.random(0, 360);
           let velocity = p5.random(4, 12);
+
+          const x = getInPreviewMode() ?
+            randomNumber(0, 400) :
+            200;
+          const y = getInPreviewMode() ?
+            randomNumber(0, 400) :
+            200;
           this.stars.push({
             color: randomColor(255, 255, 100),
-            x: 200,
-            y: 200,
+            x: x,
+            y: y,
             dx: velocity * p5.cos(theta),
             dy: velocity * p5.sin(theta),
           });
@@ -1801,7 +1840,9 @@ module.exports = class Effects {
         drawPizza(this.image.drawingContext);
       },
       draw: function (context) {
-        const centroid = context.centroid;
+        const centroid = getInPreviewMode() ?
+          6500 :
+          context.centroid;
         for (let i = 0; i < this.pizza.length; i++) {
           p5.push();
           const pizza = this.pizza[i];
@@ -1842,7 +1883,10 @@ module.exports = class Effects {
         drawSmiley(this.image.drawingContext, 0.8);
       },
       draw: function (context) {
-        const centroid = context.centroid;
+        const centroid = getInPreviewMode() ?
+          6500 :
+          context.centroid;
+
         for (let i = 0; i < this.smiles.length; i++) {
           p5.push();
           const smiles = this.smiles[i];
@@ -1866,34 +1910,69 @@ module.exports = class Effects {
     this.confetti = {
       confetti: [],
       draw: function () {
-        let confetti = {
-          x: p5.random(-100, 400),
-          y: -10,
-          velocityX: p5.random(-2, 2),
-          size: p5.random(6, 12, 18),
-          // https://github.com/Automattic/node-canvas/issues/702
-          // Bug with node-canvas prevents scaling with a value of 0, so spin initializes to 1
-          spin: 1,
-          color: randomColor(255, 255, 100),
-        };
-        this.confetti.push(confetti);
-        p5.noStroke();
-        this.confetti.forEach(function (confetti) {
-          p5.push();
-          p5.fill(confetti.color);
-          p5.translate(confetti.x, confetti.y);
-          const scaleX = p5.sin(confetti.spin);
-          p5.scale(scaleX, 1);
-          confetti.spin += 20;
-          p5.rect(0, 0, 4, confetti.size);
-          let fallSpeed = p5.map(confetti.size, 6, 12, 1, 3);
-          confetti.y += fallSpeed;
-          confetti.x += confetti.velocityX;
-          p5.pop();
-        });
-        this.confetti = this.confetti.filter(function (confetti) {
-          return confetti.y < 425;
-        });
+        if (getInPreviewMode()) {
+          for (let i = 0; i < 200; i++) {
+            let confetti = {
+              x: p5.random(-100, 400),
+              y: p5.random(-100, 400), // changed
+              velocityX: p5.random(-2, 2),
+              size: p5.random(6, 12, 18),
+              // https://github.com/Automattic/node-canvas/issues/702
+              // Bug with node-canvas prevents scaling with a value of 0, so spin initializes to 1
+              spin: 90, //changed
+              color: randomColor(255, 255, 100),
+            };
+
+            this.confetti.push(confetti);
+          }
+
+          p5.noStroke();
+          this.confetti.forEach(function (confetti) {
+            p5.push();
+            p5.fill(confetti.color);
+            p5.translate(confetti.x, confetti.y);
+            const scaleX = p5.sin(confetti.spin);
+            p5.scale(scaleX, 1);
+            confetti.spin += 20;
+            p5.rect(0, 0, 4, confetti.size);
+            let fallSpeed = p5.map(confetti.size, 6, 12, 1, 3);
+            confetti.y += fallSpeed;
+            confetti.x += confetti.velocityX;
+            p5.pop();
+          });
+          this.confetti = this.confetti.filter(function (confetti) {
+            return confetti.y < 425;
+          });
+        } else {
+          let confetti = {
+            x: p5.random(-100, 400),
+            y: -10,
+            velocityX: p5.random(-2, 2),
+            size: p5.random(6, 12, 18),
+            // https://github.com/Automattic/node-canvas/issues/702
+            // Bug with node-canvas prevents scaling with a value of 0, so spin initializes to 1
+            spin: 1,
+            color: randomColor(255, 255, 100),
+          };
+          this.confetti.push(confetti);
+          p5.noStroke();
+          this.confetti.forEach(function (confetti) {
+            p5.push();
+            p5.fill(confetti.color);
+            p5.translate(confetti.x, confetti.y);
+            const scaleX = p5.sin(confetti.spin);
+            p5.scale(scaleX, 1);
+            confetti.spin += 20;
+            p5.rect(0, 0, 4, confetti.size);
+            let fallSpeed = p5.map(confetti.size, 6, 12, 1, 3);
+            confetti.y += fallSpeed;
+            confetti.x += confetti.velocityX;
+            p5.pop();
+          });
+          this.confetti = this.confetti.filter(function (confetti) {
+            return confetti.y < 425;
+          });
+        }
       },
       reset: function () {
         this.confetti = [];
@@ -1933,17 +2012,19 @@ module.exports = class Effects {
       },
     };
 
-    // notes show up late, not previewing by resetting notes to empty array
+    // looks ok, double check though
     this.music_notes = {
       notes: [],
       init: function () {
+        const yMax = getInPreviewMode() ? 390 : 0;
+        const yMin = getInPreviewMode() ? 0 : -400;
         if (this.notes.length) {
           return;
         }
         for (let i = 0; i < 20; i++) {
           this.notes.push({
             x: randomNumber(10, 390),
-            y: randomNumber(-400, 0),
+            y: randomNumber(yMin, yMax),
             rot: randomNumber(0, 359),
             speed: 2,
             size: randomNumber(1.5, 3),
@@ -1954,27 +2035,53 @@ module.exports = class Effects {
         drawMusicNote(this.image.drawingContext);
       },
       draw: function (context) {
-        const centroid = context.centroid;
-        for (let i = 0; i < this.notes.length; i++) {
-          p5.push();
-          const notes = this.notes[i];
-          let scale = p5.map(centroid, 5000, 8000, 0, notes.size);
-          scale = p5.constrain(scale, 0, 3);
-          p5.translate(notes.x, notes.y);
-          p5.rotate(notes.rot);
-          p5.scale(scale / (4 * p5.pixelDensity()));
-          p5.drawingContext.drawImage(this.image.elt, 0, 0);
-          notes.y += notes.speed;
-          notes.rot++;
-          if (notes.y > 410) {
-            notes.x = randomNumber(10, 390);
-            notes.y = -50;
+        if (getInPreviewMode()) {
+          // changed
+          const centroid = 6500;
+          for (let i = 0; i < this.notes.length; i++) {
+            p5.push();
+            const notes = this.notes[i];
+            let scale = p5.map(centroid, 5000, 8000, 0, notes.size);
+            scale = p5.constrain(scale, 0, 3);
+            p5.translate(notes.x, notes.y);
+            p5.rotate(notes.rot);
+            p5.scale(scale / (4 * p5.pixelDensity()));
+            p5.drawingContext.drawImage(this.image.elt, 0, 0);
+            notes.y += notes.speed;
+            notes.rot++;
+            if (notes.y > 410) {
+              notes.x = randomNumber(10, 390);
+              notes.y = -50;
+            }
+            p5.pop();
           }
-          p5.pop();
+        } else {
+          const centroid = context.centroid;
+          for (let i = 0; i < this.notes.length; i++) {
+            p5.push();
+            const notes = this.notes[i];
+            let scale = p5.map(centroid, 5000, 8000, 0, notes.size);
+            scale = p5.constrain(scale, 0, 3);
+            p5.translate(notes.x, notes.y);
+            p5.rotate(notes.rot);
+            p5.scale(scale / (4 * p5.pixelDensity()));
+            p5.drawingContext.drawImage(this.image.elt, 0, 0);
+            notes.y += notes.speed;
+            notes.rot++;
+            if (notes.y > 410) {
+              notes.x = randomNumber(10, 390);
+              notes.y = -50;
+            }
+            p5.pop();
+          }
         }
       },
+      reset: function () {
+        this.notes = [];
+      }
     };
 
+    // to do
     this.paint_drip = {
       current_drip: 0,
       current_drip_height: 0,
@@ -2172,31 +2279,59 @@ module.exports = class Effects {
       },
 
       draw: function () {
-        if (p5.frameCount % 10 === 0) {
-          // generate new emoji every 10 frames
-          this.emojiList.push({
-            x: randomNumber(0, 350),
-            y: -50,
-            size: randomNumber(50, 90),
-            image: this.emojiTypes[randomNumber(0, 4)],
-          });
-        }
-        for (let i = 0; i < this.emojiList.length; ++i) {
-          const emoji = this.emojiList[i];
-          emoji.y += p5.pow(emoji.size, 0.25); // emoji falls at a rate fourth root to its size
-          if (emoji.y > p5.height * 1.2) {
-            // if the emoji has fallen past 120% of the screen
-            this.emojiList.splice(i, 1);
+        if (getInPreviewMode()) {
+          for (let i = 0; i < 12; i++) {
+            this.emojiList.push({
+              x: randomNumber(0, 350),
+              y: randomNumber(0, 350), // changed
+              size: randomNumber(50, 90),
+              image: this.emojiTypes[randomNumber(0, 4)],
+            });
           }
-          p5.push();
-          p5.drawingContext.drawImage(
-            emoji.image.elt,
-            emoji.x,
-            emoji.y,
-            emoji.size,
-            emoji.size
-          );
-          p5.pop();
+          for (let i = 0; i < this.emojiList.length; ++i) {
+            const emoji = this.emojiList[i];
+            emoji.y += p5.pow(emoji.size, 0.25); // emoji falls at a rate fourth root to its size
+            if (emoji.y > p5.height * 1.2) {
+              // if the emoji has fallen past 120% of the screen
+              this.emojiList.splice(i, 1);
+            }
+            p5.push();
+            p5.drawingContext.drawImage(
+              emoji.image.elt,
+              emoji.x,
+              emoji.y,
+              emoji.size,
+              emoji.size
+            );
+            p5.pop();
+          }
+        } else {
+          if (p5.frameCount % 10 === 0) {
+            // generate new emoji every 10 frames
+            this.emojiList.push({
+              x: randomNumber(0, 350),
+              y: -50,
+              size: randomNumber(50, 90),
+              image: this.emojiTypes[randomNumber(0, 4)],
+            });
+          }
+          for (let i = 0; i < this.emojiList.length; ++i) {
+            const emoji = this.emojiList[i];
+            emoji.y += p5.pow(emoji.size, 0.25); // emoji falls at a rate fourth root to its size
+            if (emoji.y > p5.height * 1.2) {
+              // if the emoji has fallen past 120% of the screen
+              this.emojiList.splice(i, 1);
+            }
+            p5.push();
+            p5.drawingContext.drawImage(
+              emoji.image.elt,
+              emoji.x,
+              emoji.y,
+              emoji.size,
+              emoji.size
+            );
+            p5.pop();
+          }
         }
       },
       reset: function () {

--- a/src/Effects.js
+++ b/src/Effects.js
@@ -27,7 +27,6 @@ module.exports = class Effects {
     this.blend = blend || p5.BLEND;
     this.currentPalette = currentPalette;
     this.inPreviewMode = false;
-    const getInPreviewMode = this.getInPreviewMode.bind(this);
 
     function randomNumber(min, max) {
       return Math.round(p5.random(min, max));
@@ -862,7 +861,7 @@ module.exports = class Effects {
           const pineapple = this.pineappleList[i];
           p5.translate(pineapple.x, pineapple.y);
           p5.rotate(pineapple.rot);
-          p5.scale(this.inPreviewMode() ? 2 / (7 * p5.pixelDensity()) : pineapple.life / 20 / (7 * p5.pixelDensity()));
+          p5.scale(pineapple.life / 20 / (7 * p5.pixelDensity()));
           p5.drawingContext.drawImage(this.image.elt, -35, -65);
           pineapple.life--;
           if (pineapple.life < 0) {
@@ -873,7 +872,9 @@ module.exports = class Effects {
           p5.pop();
         }
       },
-      inPreviewMode: getInPreviewMode,
+      reset: function () {
+        this.pineappleList = [];
+      },
     };
 
     this.splatter = {
@@ -1313,7 +1314,7 @@ module.exports = class Effects {
           p5.push();
           p5.translate(poop.x, poop.y);
           p5.rotate(poop.rot);
-          p5.scale(this.inPreviewMode() ? 2 : poop.life / 20);
+          p5.scale(poop.life / 20);
           drawPoop(p5._renderer.drawingContext);
           poop.life--;
           if (poop.life < 0) {
@@ -1324,7 +1325,9 @@ module.exports = class Effects {
           p5.pop();
         }
       },
-      inPreviewMode: getInPreviewMode,
+      reset: function () {
+        this.poopList = [];
+      },
     };
 
     this.hearts_red = {
@@ -1359,6 +1362,9 @@ module.exports = class Effects {
           p5.pop();
         }
       },
+      reset: function () {
+        this.heartList = [];
+      }
     };
 
     this.hearts_colorful = {
@@ -1393,6 +1399,9 @@ module.exports = class Effects {
           }
           p5.pop();
         }
+      },
+      reset: function () {
+        this.heartList = [];
       },
     };
 
@@ -1628,6 +1637,9 @@ module.exports = class Effects {
           return bubble.y > 0;
         });
       },
+      reset: function () {
+        this.bubble = [];
+      },
     };
 
     this.stars = {
@@ -1667,14 +1679,15 @@ module.exports = class Effects {
     // as well, though.
     this.exploding_stars = {
       stars: [],
-      resetStars: function () {
+      reset: function () {
+        this.stars = [];
         for (let i = 0; i < 100; i++) {
           let theta = p5.random(0, 360);
           let velocity = p5.random(4, 12);
           this.stars.push({
             color: randomColor(255, 255, 100),
-            x: this.inPreviewMode() ? p5.random(0, 400) : 200,
-            y: this.inPreviewMode() ? p5.random(0, 400) : 200,
+            x: 200,
+            y: 200,
             dx: velocity * p5.cos(theta),
             dy: velocity * p5.sin(theta),
           });
@@ -1684,7 +1697,7 @@ module.exports = class Effects {
         p5.angleMode(p5.DEGREES);
         p5.noStroke();
         if (this.stars.length === 0) {
-          this.resetStars();
+          this.reset();
         }
         this.stars.forEach(star => {
           p5.fill(star.color);
@@ -1696,7 +1709,6 @@ module.exports = class Effects {
           star => star.x > -10 && star.x < 410 && star.y > -10 && star.y < 410
         );
       },
-      inPreviewMode: getInPreviewMode
     };
 
     this.galaxy = {
@@ -1848,6 +1860,9 @@ module.exports = class Effects {
           return confetti.y < 425;
         });
       },
+      reset: function () {
+        this.confetti = [];
+      },
     };
 
     this.growing_stars = {
@@ -1883,6 +1898,7 @@ module.exports = class Effects {
       },
     };
 
+    // notes show up late, not previewing by resetting notes to empty array
     this.music_notes = {
       notes: [],
       init: function () {
@@ -1934,6 +1950,12 @@ module.exports = class Effects {
       drip_diameter: 20,
       drip_speed: 7,
 
+      // doesn't do much
+      // not sure if dripping_up reset necessary
+      reset: function () {
+        this.init();
+        this.dripping_up = false;
+      },
       init: function () {
         // Reset values
         this.current_drip = 0;
@@ -2082,6 +2104,7 @@ module.exports = class Effects {
       },
     };
 
+    // preview not working
     this.emojis = {
       emojiList: [],
       emojiTypes: [],
@@ -2141,15 +2164,10 @@ module.exports = class Effects {
           p5.pop();
         }
       },
+      reset: function () {
+        this.emojiList = [];
+      }
     };
-  }
-
-  setInPreviewMode(inPreviewMode) {
-    this.inPreviewMode = inPreviewMode;
-  }
-
-  getInPreviewMode() {
-    return this.inPreviewMode;
   }
 
   randomForegroundEffect() {

--- a/src/Effects.js
+++ b/src/Effects.js
@@ -688,7 +688,6 @@ module.exports = class Effects {
       },
     };
 
-    // looks good in production
     this.rain = {
       drops: [],
       init: function () {
@@ -884,7 +883,7 @@ module.exports = class Effects {
 
           p5.translate(pineapple.x, pineapple.y);
           p5.rotate(pineapple.rot);
-          p5.scale(scale); // changed
+          p5.scale(scale);
           p5.drawingContext.drawImage(this.image.elt, -35, -65);
           pineapple.life--;
           if (pineapple.life < 0) {
@@ -1011,7 +1010,6 @@ module.exports = class Effects {
       },
     };
 
-    // looks ok?
     this.spotlight = {
       x: 200,
       y: 200,
@@ -1156,7 +1154,6 @@ module.exports = class Effects {
       },
     };
 
-    // looks good?
     this.color_lights = {
       lights: [],
       newLight: function (x, arc, offset) {
@@ -1406,7 +1403,6 @@ module.exports = class Effects {
       }
     };
 
-    // seems fine as is in production (doesn't reset though)
     this.hearts_colorful = {
       heartList: [],
       init: function () {
@@ -1439,9 +1435,6 @@ module.exports = class Effects {
           }
           p5.pop();
         }
-      },
-      reset: function () {
-        this.heartList = [];
       },
     };
 
@@ -1992,7 +1985,7 @@ module.exports = class Effects {
       },
     };
 
-    // looks ok, double check though
+    // reset with no notes on screen not previewing correctly :/
     this.music_notes = {
       notes: [],
       init: function () {
@@ -2070,13 +2063,13 @@ module.exports = class Effects {
           this.crayons.push({maxHeight: 0, startFrame: 0});
         }
       },
-
       draw: function () {
         for (let i = 0; i < this.crayons.length; i++) {
           let c = lerpColorFromSpecificPalette('neon', i / this.crayons.length);
           p5.fill(c);
           p5.noStroke();
-          let rectHeight = this.start_height;
+          let rectHeight = this.getPreviewCustomizations().getRectHeight();
+
 
           // Drip is to the left of moving drip and should be stationary at full height
           if (i < this.current_drip) {
@@ -2103,6 +2096,10 @@ module.exports = class Effects {
             this.drip_diameter,
             this.drip_diameter
           );
+        }
+
+        if (getInPreviewMode()) {
+          return;
         }
 
         // Check if the current drip is 'done'
@@ -2140,6 +2137,12 @@ module.exports = class Effects {
           this.crayons[this.current_drip].startFrame = p5.frameCount;
         }
       },
+      // buggy, maybe skip advance drawing in preview?
+      getPreviewCustomizations: function () {
+        return getInPreviewMode() ?
+          {getRectHeight: () => p5.random(30, 200)} :
+          {getRectHeight: () => this.start_height};
+      }
     };
 
     this.squiggles = {

--- a/src/Effects.js
+++ b/src/Effects.js
@@ -74,7 +74,6 @@ module.exports = class Effects {
       return this.currentPalette;
     };
 
-    // figure out what to do here with foregrounds
     this.none = {
       draw: function ({backgroundColor}) {
         p5.background(backgroundColor || 'white');
@@ -799,14 +798,12 @@ module.exports = class Effects {
       },
     };
 
-    // reset clicked with no tacos on the screen
-    // doesn't preview any tacos
     this.raining_tacos = {
       tacos: [],
       init: function () {
-        // if (this.tacos.length) {
-        //   return;
-        // }
+        if (this.tacos.length) {
+          return;
+        }
         for (let i = 0; i < 10; i++) {
           this.tacos.push({
             x: randomNumber(20, 380),
@@ -842,7 +839,6 @@ module.exports = class Effects {
       },
       reset: function () {
         this.tacos = [];
-        this.init();
       },
       getPreviewCustomizations: function () {
         return getInPreviewMode() ?
@@ -1365,7 +1361,6 @@ module.exports = class Effects {
       },
     };
 
-    // seems fine as is in production (doesn't reset though)
     this.hearts_red = {
       heartList: [],
       init: function () {
@@ -1436,10 +1431,11 @@ module.exports = class Effects {
           p5.pop();
         }
       },
+      reset: function () {
+        this.heartList = [];
+      }
     };
 
-    // init happens on setting of foreground
-    // reset happens on reset() (before each run)?
     this.floating_rainbows = {
       rainbows: [],
       init: function () {
@@ -1447,7 +1443,6 @@ module.exports = class Effects {
           return;
         }
 
-        // check if y is varying
         for (let i = 0; i < 15; i++) {
           this.rainbows.push({
             x: randomNumber(10, 390),
@@ -1734,8 +1729,6 @@ module.exports = class Effects {
       },
     };
 
-    // reset button is putting all the stars in the middle
-    // instead of spreading out
     this.exploding_stars = {
       stars: [],
       reset: function () {
@@ -2035,7 +2028,6 @@ module.exports = class Effects {
       },
     };
 
-    // to do
     this.paint_drip = {
       current_drip: 0,
       current_drip_height: 0,
@@ -2046,8 +2038,6 @@ module.exports = class Effects {
       drip_diameter: 20,
       drip_speed: 7,
 
-      // doesn't do much
-      // not sure if dripping_up reset necessary
       reset: function () {
         this.init();
         this.dripping_up = false;
@@ -2069,7 +2059,6 @@ module.exports = class Effects {
           p5.fill(c);
           p5.noStroke();
           let rectHeight = this.getPreviewCustomizations().getRectHeight();
-
 
           // Drip is to the left of moving drip and should be stationary at full height
           if (i < this.current_drip) {
@@ -2096,10 +2085,6 @@ module.exports = class Effects {
             this.drip_diameter,
             this.drip_diameter
           );
-        }
-
-        if (getInPreviewMode()) {
-          return;
         }
 
         // Check if the current drip is 'done'

--- a/src/Effects.js
+++ b/src/Effects.js
@@ -2250,6 +2250,10 @@ module.exports = class Effects {
       getPreviewCustomizations: function () {
         if (getInPreviewMode()) {
           const addEmojisPreview = () => {
+            if (this.emojiList.length) {
+              return;
+            }
+
             for (let i = 0; i < 12; i++) {
               this.emojiList.push({
                 x: randomNumber(0, 350),

--- a/src/Effects.js
+++ b/src/Effects.js
@@ -27,6 +27,8 @@ module.exports = class Effects {
     this.blend = blend || p5.BLEND;
     this.currentPalette = currentPalette;
     this.inPreviewMode = false;
+    const getInPreviewMode = this.getInPreviewMode.bind(this);
+
 
     function randomNumber(min, max) {
       return Math.round(p5.random(min, max));
@@ -72,6 +74,7 @@ module.exports = class Effects {
       return this.currentPalette;
     };
 
+    // figure out what to do here with foregrounds
     this.none = {
       draw: function ({backgroundColor}) {
         p5.background(backgroundColor || 'white');
@@ -1614,28 +1617,60 @@ module.exports = class Effects {
     this.bubbles = {
       bubble: [],
       draw: function () {
-        let bubble = {
-          x: p5.random(-100, 400),
-          y: 410,
-          velocityX: p5.random(-2, 2),
-          size: p5.random(6, 12, 18),
-          color: randomColor(100, 50, 0.25),
-        };
-        this.bubble.push(bubble);
-        p5.noStroke();
-        this.bubble.forEach(function (bubble) {
-          p5.push();
-          p5.fill(bubble.color);
-          p5.translate(bubble.x, bubble.y);
-          p5.ellipse(0, 0, bubble.size, bubble.size);
-          let fallSpeed = p5.map(bubble.size, 6, 12, 1, 3);
-          bubble.y -= fallSpeed;
-          bubble.x += bubble.velocityX;
-          p5.pop();
-        });
-        this.bubble = this.bubble.filter(function (bubble) {
-          return bubble.y > 0;
-        });
+        if (getInPreviewMode()) {
+          for (let i = 1; i < 200; i++) {
+            let bubble = {
+              x: p5.random(-100, 400),
+              y: p5.random(-100, 400),
+              velocityX: p5.random(-2, 2),
+              size: p5.random(6, 12, 18),
+              color: randomColor(100, 50, 0.25),
+            };
+            this.bubble.push(bubble);
+          }
+
+          p5.noStroke();
+
+          this.bubble.forEach(function (bubble) {
+            p5.push();
+            p5.fill(bubble.color);
+            p5.translate(bubble.x, bubble.y);
+            p5.ellipse(0, 0, bubble.size, bubble.size);
+            let fallSpeed = p5.map(bubble.size, 6, 12, 1, 3);
+            bubble.y -= fallSpeed;
+            bubble.x += bubble.velocityX;
+            p5.pop();
+          });
+          this.bubble = this.bubble.filter(function (bubble) {
+            return bubble.y > 0;
+          });
+
+        } else {
+          // reset here?
+          // prob don't want to...
+          let bubble = {
+            x: p5.random(-100, 400),
+            y: 410,
+            velocityX: p5.random(-2, 2),
+            size: p5.random(6, 12, 18),
+            color: randomColor(100, 50, 0.25),
+          };
+          this.bubble.push(bubble);
+          p5.noStroke();
+          this.bubble.forEach(function (bubble) {
+            p5.push();
+            p5.fill(bubble.color);
+            p5.translate(bubble.x, bubble.y);
+            p5.ellipse(0, 0, bubble.size, bubble.size);
+            let fallSpeed = p5.map(bubble.size, 6, 12, 1, 3);
+            bubble.y -= fallSpeed;
+            bubble.x += bubble.velocityX;
+            p5.pop();
+          });
+          this.bubble = this.bubble.filter(function (bubble) {
+            return bubble.y > 0;
+          });
+        }
       },
       reset: function () {
         this.bubble = [];
@@ -2168,6 +2203,14 @@ module.exports = class Effects {
         this.emojiList = [];
       }
     };
+  }
+
+  setInPreviewMode(inPreviewMode) {
+    this.inPreviewMode = inPreviewMode;
+  }
+
+  getInPreviewMode() {
+    return this.inPreviewMode;
   }
 
   randomForegroundEffect() {

--- a/src/Effects.js
+++ b/src/Effects.js
@@ -1730,7 +1730,7 @@ module.exports = class Effects {
 
     this.exploding_stars = {
       stars: [],
-      reset: function () {
+      init: function () {
         this.stars = [];
         for (let i = 0; i < 100; i++) {
           let theta = p5.random(0, 360);
@@ -1749,7 +1749,7 @@ module.exports = class Effects {
         p5.angleMode(p5.DEGREES);
         p5.noStroke();
         if (this.stars.length === 0) {
-          this.reset();
+          this.init();
         }
         this.stars.forEach(star => {
           p5.fill(star.color);

--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -312,6 +312,10 @@ module.exports = class DanceParty {
     this.world.keysPressed = new Set();
   }
 
+  setForegroundEffectsInPreviewMode(inPreviewMode) {
+    this.fgEffects_ && this.fgEffects_.setInPreviewMode(inPreviewMode);
+  }
+
   setAnimationSpriteSheet(sprite, moveIndex, spritesheet, mirror, animation) {
     this.animations[sprite][moveIndex] = {
       spritesheet: spritesheet,

--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -325,11 +325,9 @@ module.exports = class DanceParty {
   }
 
   setup() {
-    console.log('setup run');
     this.bgEffects_ = new Effects(this.p5_, 1, this.extraImages);
     this.fgEffects_ = new Effects(this.p5_, 0.8, this.extraImages);
 
-    // what is this
     this.performanceData_.initTime = timeSinceLoad();
     this.onInit && this.onInit(this);
   }

--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -301,7 +301,7 @@ module.exports = class DanceParty {
     }
 
     let foregroundEffect = this.getForegroundEffect();
-    if (foregroundEffect.reset) {
+    if (foregroundEffect && foregroundEffect.reset) {
       foregroundEffect.reset();
     }
 
@@ -339,14 +339,13 @@ module.exports = class DanceParty {
   }
 
   getForegroundEffect() {
-    return this.fgEffects_[this.world.fg_effect || 'none'];
-    // if (
-    //   this.world.fg_effect &&
-    //   this.world.fg_effect !== null &&
-    //   this.world.fg_effect !== 'none'
-    // ) {
-    //   return this.fgEffects_[this.world.fg_effect];
-    // }
+    if (
+      this.world.fg_effect &&
+      this.world.fg_effect !== null &&
+      this.world.fg_effect !== 'none'
+    ) {
+      return this.fgEffects_[this.world.fg_effect];
+    }
   }
 
   play(songData, callback) {

--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -300,15 +300,16 @@ module.exports = class DanceParty {
       backgroundEffect.reset();
     }
 
+    let foregroundEffect = this.getForegroundEffect();
+    if (foregroundEffect.reset) {
+      foregroundEffect.reset();
+    }
+
     this.world.background_color = null;
     this.world.fg_effect = null;
     this.world.bg_effect = null;
     this.world.validationState = {};
     this.world.keysPressed = new Set();
-  }
-
-  setForegroundEffectsInPreviewMode(inPreviewMode) {
-    this.fgEffects_ && this.fgEffects_.setInPreviewMode(inPreviewMode);
   }
 
   setAnimationSpriteSheet(sprite, moveIndex, spritesheet, mirror, animation) {
@@ -334,13 +335,14 @@ module.exports = class DanceParty {
   }
 
   getForegroundEffect() {
-    if (
-      this.world.fg_effect &&
-      this.world.fg_effect !== null &&
-      this.world.fg_effect !== 'none'
-    ) {
-      return this.fgEffects_[this.world.fg_effect];
-    }
+    return this.fgEffects_[this.world.fg_effect || 'none'];
+    // if (
+    //   this.world.fg_effect &&
+    //   this.world.fg_effect !== null &&
+    //   this.world.fg_effect !== 'none'
+    // ) {
+    //   return this.fgEffects_[this.world.fg_effect];
+    // }
   }
 
   play(songData, callback) {

--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -307,6 +307,10 @@ module.exports = class DanceParty {
     this.world.keysPressed = new Set();
   }
 
+  setForegroundEffectsInPreviewMode(inPreviewMode) {
+    this.fgEffects_ && this.fgEffects_.setInPreviewMode(inPreviewMode);
+  }
+
   setAnimationSpriteSheet(sprite, moveIndex, spritesheet, mirror, animation) {
     this.animations[sprite][moveIndex] = {
       spritesheet: spritesheet,
@@ -316,9 +320,11 @@ module.exports = class DanceParty {
   }
 
   setup() {
+    console.log('setup run');
     this.bgEffects_ = new Effects(this.p5_, 1, this.extraImages);
     this.fgEffects_ = new Effects(this.p5_, 0.8, this.extraImages);
 
+    // what is this
     this.performanceData_.initTime = timeSinceLoad();
     this.onInit && this.onInit(this);
   }


### PR DESCRIPTION
Supports showing foreground effects in preview. General approach here is to modify effects that were not rendering in preview as minimally as possible to get something rendered that approximated the effect, and adding some reset functionality such that foregrounds are reset before students hit the run button.

From a code style perspective, the customizations required varied across effects, which felt a little yucky. I tried to use a standard approach to these customizations and keep them all together within each effect, such that they'll be findable in the future.

Should have no impact on effects being used in Dance Party levels/projects today that do not use the preview feature.

See companion PR in code-dot-org here: https://github.com/code-dot-org/code-dot-org/pull/54307

**New foreground previews**

https://github.com/code-dot-org/dance-party/assets/25372625/05ef7f0d-b62d-45b6-a340-3b2895587e9b

## Testing story

I manually tested:
- a) selecting each foreground,
- b) seeing the preview render with the selected foreground,
- c) seeing the effect reset once the run button is clicked (eg, displaying no bubbles at the beginning of the animation), and
- d) seeing the preview "reset" once the reset button was clicked

I also tested removing/adding the foreground block to the main setup block, and saw the foreground effect removed/added from the preview as appropriate.

## Follow-up work

- Paint dripping is a little funky (especially the left most drip), but that seems to be an existing issue.