### PR TITLE
Support "at x measures" block

### DIFF
--- a/src/p5.dance.interpreted.js
+++ b/src/p5.dance.interpreted.js
@@ -178,14 +178,31 @@ function whenPeak(range, func) {
 }
 
 /**
+ * Execute code at a specified time, either in measures or seconds.
+ * One idiosyncrasy: despite the function's name, if we call atTimestamp(4, "measures", foo),
+ * we actually fire on the 5th measure (i.e after 4 measures have completed).
  * @param {number} timestamp
  * @param {string} unit - Should be "measures" or "seconds"
  * @param {function} func - Code to run when event fires
  */
 function atTimestamp(timestamp, unit, func) {
-  // Despite the functions name, if we call atTimestamp(4, "measures", foo), we
-  // actually want to fire on the 5th measure (i.e after 4 measures have completed)
-  if (unit === 'measures') {
+  atTimestampEventGenerator(timestamp, unit, func, true);
+}
+
+/**
+ * Execute code at a specified time, either in measures or seconds.
+ * Has "NotAfter" suffix to distinguish from "atTimestamp",
+ * which executes code **AFTER** x measures (if time is specified in measures).
+ * @param {number} timestamp
+ * @param {string} unit - Should be "measures" or "seconds"
+ * @param {function} func - Code to run when event fires
+ */
+function atTimestampNotAfter(timestamp, unit, func) {
+  atTimestampEventGenerator(timestamp, unit, func, false);
+}
+
+function atTimestampEventGenerator(timestamp, unit, func, afterMeasure) {
+  if (unit === 'measures' && afterMeasure) {
     timestamp += 1;
   }
 

--- a/src/p5.dance.interpreted.js
+++ b/src/p5.dance.interpreted.js
@@ -201,6 +201,13 @@ function atTimestampNotAfter(timestamp, unit, func) {
   atTimestampEventGenerator(timestamp, unit, func, false);
 }
 
+/**
+ * Add events for code to execute at a specified time.
+ * @param {number} timestamp
+ * @param {string} unit - Should be "measures" or "seconds"
+ * @param {function} func - Code to run when event fires
+ * @param {boolean} afterMeasure - If unit is "measures", set event to occur at end of measure (supports legacy block)
+ */
 function atTimestampEventGenerator(timestamp, unit, func, afterMeasure) {
   if (unit === 'measures' && afterMeasure) {
     timestamp += 1;


### PR DESCRIPTION
Support a new "at X measures" block, which is only distinct from our existing "after X measures" block in that it runs right when we hit X measures (rather than after the measure, ie X + 1).

Open to suggestions on naming :)

Companion PR (with screenshots) in `code-dot-org` here: https://github.com/code-dot-org/code-dot-org/pull/54369