### PR TITLE
Dance AI: Live Preview

### DIFF
--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -54,7 +54,6 @@ module.exports = class DanceParty {
     // to load fixtures and/or isolate us entirely from network activity
     resourceLoader = new ResourceLoader(),
   }) {
-    console.log('WILLIAM SHAKESPEARE !!');
     this.onHandleEvents = onHandleEvents;
     this.onInit = onInit;
     this.showMeasureLabel = showMeasureLabel;

--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -366,10 +366,6 @@ module.exports = class DanceParty {
   }
 
   livePreview(songData) {
-    if (!this.getForegroundEffectsInPreviewMode()) {
-      console.warn('livePreview() called while not in preview mode!');
-      this.setForegroundEffectsInPreviewMode(true);
-    }
     this.songMetadata_ = modifySongData(songData);
     this.analysisPosition_ = 0;
     this.songStartTime_ = new Date();

--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -327,10 +327,6 @@ module.exports = class DanceParty {
     this.bgEffects_ && this.bgEffects_.setInPreviewMode(inPreviewMode);
   }
 
-  getForegroundEffectsInPreviewMode() {
-    return this.fgEffects_ && this.fgEffects_.getInPreviewMode();
-  }
-
   setAnimationSpriteSheet(sprite, moveIndex, spritesheet, mirror, animation) {
     this.animations[sprite][moveIndex] = {
       spritesheet: spritesheet,
@@ -370,21 +366,6 @@ module.exports = class DanceParty {
     this.analysisPosition_ = 0;
     this.songStartTime_ = new Date();
     this.p5_.loop();
-  }
-
-  staticPreview() {
-    if (!this.getForegroundEffectsInPreviewMode()) {
-      console.warn('staticPreview() called while not in preview mode!');
-      this.setForegroundEffectsInPreviewMode(true);
-    }
-    // Force preview draw to occur **after** any
-    // draw iterations already queued up.
-    // redraw() (rather than draw()) is p5's recommended way
-    // of drawing once.
-    setTimeout(() => {
-      this.p5_.redraw();
-      this.setForegroundEffectsInPreviewMode(false);
-    }, 0);
   }
 
   play(songData, callback, userBlockTypes) {
@@ -1178,10 +1159,7 @@ module.exports = class DanceParty {
   ai(params) {
     this.world.aiBlockCalled = true;
     console.log('handle AI:', params);
-    if (
-      this.contextType === constants.KEY_WENT_DOWN_EVENT_TYPE &&
-      this.contextKey
-    ) {
+    if (this.contextType === constants.KEY_WENT_DOWN_EVENT_TYPE && this.contextKey) {
       // Note that this.contextKey is the key that was pressed to trigger this AI block, e.g., 'up', 'down',...
       this.world.aiBlockContextUserEventKey = this.contextKey;
     }
@@ -1391,8 +1369,7 @@ module.exports = class DanceParty {
 
     for (let key of WATCHED_KEYS) {
       if (this.p5_.keyWentDown(key)) {
-        events[constants.KEY_WENT_DOWN_EVENT_TYPE] =
-          events[constants.KEY_WENT_DOWN_EVENT_TYPE] || {};
+        events[constants.KEY_WENT_DOWN_EVENT_TYPE] = events[constants.KEY_WENT_DOWN_EVENT_TYPE] || {};
         events[constants.KEY_WENT_DOWN_EVENT_TYPE][key] = true;
         this.world.keysPressed.add(key);
       }

--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -320,7 +320,6 @@ module.exports = class DanceParty {
     this.world.bg_effect = null;
     this.world.validationState = {};
     this.world.keysPressed = new Set();
-    this.setForegroundEffectsInPreviewMode(false);
   }
 
   setForegroundEffectsInPreviewMode(inPreviewMode) {


### PR DESCRIPTION
Enable live preview. Internally, this calls on `p5` to start looping and sets various flags and data related to song metadata. This is more or less just `play()` without song playback and validation callbacks, etc.

Pairs with https://github.com/code-dot-org/code-dot-org/pull/54466

https://github.com/code-dot-org/dance-party/assets/85528507/c69ab167-95be-4d36-b22f-a1ba8d710464