### PR TITLE
Loop animations in live preview

### DIFF
--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -142,6 +142,9 @@ module.exports = class DanceParty {
 
     this.songStartTime_ = 0;
 
+    // Whether to loop analysis events. Used in live preview.
+    this.loopAnalysisEvents = false;
+
     new P5(p5Inst => {
       this.p5_ = p5Inst;
       this.resourceLoader_.initWithP5(p5Inst);
@@ -316,6 +319,8 @@ module.exports = class DanceParty {
     this.world.bg_effect = null;
     this.world.validationState = {};
     this.world.keysPressed = new Set();
+
+    this.loopAnalysisEvents = false;
   }
 
   setEffectsInPreviewMode(inPreviewMode) {
@@ -361,6 +366,7 @@ module.exports = class DanceParty {
     this.songMetadata_ = modifySongData(songData);
     this.analysisPosition_ = 0;
     this.songStartTime_ = new Date();
+    this.loopAnalysisEvents = true;
     this.p5_.loop();
   }
 
@@ -1387,6 +1393,13 @@ module.exports = class DanceParty {
         }
       }
       this.analysisPosition_++;
+    }
+
+    // If we've reached the end of the analysis events and are looping, reset
+    // to the beginning. This is only used in live preview (where there is no song playback).
+    if (this.loopAnalysisEvents && this.analysisPosition_ >= length) {
+      this.analysisPosition_ = 0;
+      this.songStartTime_ = Date.now();
     }
 
     while (


### PR DESCRIPTION
Allow animations to loop in live preview, as suggested in https://github.com/code-dot-org/code-dot-org/pull/54694. This allows us to keep the preview metadata JSON relatively small and lets live preview run for however long.

Tested locally with a variety of BG/FG effects.