### PR TITLE
Add world variables to support new validation support for AI Dance Party

### DIFF
--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -83,6 +83,9 @@ module.exports = class DanceParty {
 
     this.world.keysPressed = new Set();
 
+    this.world.spriteGroupsCalledToChangeMove = [];
+    this.world.spriteStyles = [];
+
     this.peakThisFrame_ = false;
     this.energy_ = 0;
     this.centroid_ = 0;
@@ -316,6 +319,8 @@ module.exports = class DanceParty {
     this.world.bg_effect = null;
     this.world.validationState = {};
     this.world.keysPressed = new Set();
+    this.world.spriteGroupsCalledToChangeMove = [];
+    this.world.spriteStyles = [];
   }
 
   setEffectsInPreviewMode(inPreviewMode) {
@@ -448,6 +453,7 @@ module.exports = class DanceParty {
     }
 
     sprite.style = costume;
+    this.world.spriteStyles.push(costume);
     this.getGroupByName_(costume).add(sprite);
 
     sprite.mirroring = 1;
@@ -697,6 +703,7 @@ module.exports = class DanceParty {
   }
 
   changeMoveEachLR(group, move, dir) {
+    this.world.spriteGroupsCalledToChangeMove.push(group);
     group = this.getGroupByName_(group);
     if (move === 'rand' && group.length > 0) {
       move = this.getNewChangedMove(move, group[0].current_move, false);

--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -83,6 +83,7 @@ module.exports = class DanceParty {
 
     this.world.keysPressed = new Set();
 
+    // These variables are used for validation support.
     this.world.spriteGroupsCalledToChangeMove = [];
     this.world.spriteStyles = [];
 
@@ -296,6 +297,7 @@ module.exports = class DanceParty {
     this.allSpritesLoaded = false;
     this.songStartTime_ = 0;
     this.analysisPosition_ = 0;
+    // The following three world variables are used for validation support.
     this.world.aiBlockCalled = false;
     this.world.aiBlockContextUserEventKey = null;
     // This value is set to `true` if any of the AI blocks in a user program


### PR DESCRIPTION
This PR adds two new `world` variables to provide more validation support for Dance Party levels.

The curriculum team would like to give more targeted feedback for common user errors. The particular case that motivated the addition of this validation support is in the Dance Party progression, [level 2](https://studio.code.org/s/dance-ai-2023/lessons/1/levels/2). The user is asked to create a dancer (`makeAnonymousDanceSprite`), then have it do a new dance move (`changeMoveEachLR`). 

A common bug is when the two blocks (are out of order. Currently, the feedback is inaccurate because the curriculum team also wanted to address the other common error which is when the two blocks are in the correct order but they don't have matching costumes. Now we provide support for the case when the two blocks have the same costume but are out of order.
 
Before update:

https://github.com/code-dot-org/code-dot-org/assets/107423305/3de73440-ac3f-4fce-a8d9-7bcdf4cc2731


After update:

https://github.com/code-dot-org/code-dot-org/assets/107423305/c5496179-8af2-4199-91fd-7de6ea0ed042

