### PR TITLE
Handle invalid background/foreground effects

### DIFF
--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -46,6 +46,7 @@ module.exports = class DanceParty {
     showMeasureLabel = true,
     container,
     spriteConfig,
+    logger,
     i18n = {
       measure: () => 'Measure:',
     },
@@ -150,6 +151,8 @@ module.exports = class DanceParty {
     this.loopAnalysisEvents = false;
     this.livePreviewStopTime = 0;
 
+    this.logger = logger;
+
     new P5(p5Inst => {
       this.p5_ = p5Inst;
       this.resourceLoader_.initWithP5(p5Inst);
@@ -193,7 +196,7 @@ module.exports = class DanceParty {
 
   async loadCostumeAnimations(costume, costumeData) {
     if (!this.animations[costume]) {
-      console.log('Unexpected costume: ' + costume);
+      this.logWarning('Unexpected costume: ' + costume);
       // Invalid costume, nothing to do:
       return;
     }
@@ -425,6 +428,17 @@ module.exports = class DanceParty {
     if (constants.RANDOM_EFFECT_KEY === palette) {
       palette = this.bgEffects_.randomBackgroundPalette();
     }
+
+    if (this.bgEffects_[effect] === undefined) {
+      this.logWarning('Unknown background effect: ' + effect);
+      return;
+    }
+
+    if (constants.PALETTES[palette] === undefined) {
+      this.logWarning('Unknown palette: ' + palette);
+      return;
+    }
+
     this.world.bg_effect = effect;
     this.bgEffects_.currentPalette = palette;
 
@@ -437,6 +451,12 @@ module.exports = class DanceParty {
     if (constants.RANDOM_EFFECT_KEY === effect) {
       effect = this.fgEffects_.randomForegroundEffect();
     }
+
+    if (this.fgEffects_[effect] === undefined) {
+      this.logWarning('Unknown foreground effect: ' + effect);
+      return;
+    }
+
     this.world.fg_effect = effect;
 
     if (this.fgEffects_[effect].init) {
@@ -1023,7 +1043,7 @@ module.exports = class DanceParty {
         sprite.rotation = 0;
       });
     } else {
-      console.log('Unexpected layout format: ' + format);
+      this.logWarning('Unexpected layout format: ' + format);
     }
 
     // We want sprites that are lower in the canvas to show up on top of those
@@ -1473,6 +1493,11 @@ module.exports = class DanceParty {
 
   registerValidation(callback) {
     this.world.validationCallback = callback;
+  }
+
+  logWarning(message) {
+    this.logger && this.logger.logWarning(message);
+    console.warn(message);
   }
 
   draw() {

--- a/test/unit/effectsTest.js
+++ b/test/unit/effectsTest.js
@@ -1,4 +1,5 @@
 const test = require('tape');
+const sinon = require('sinon');
 const helpers = require('../helpers/createDanceAPI');
 
 test('setBackground clears the bgEffect and sets background_color', async t => {
@@ -136,4 +137,67 @@ test('random foreground effect', async t => {
 
   t.end();
   nativeAPI.reset();
+});
+
+test('logs invalid background effect', async t => {
+  const invalidEffect = 'invalid';
+  const loggerSpy = {
+    logWarning: sinon.spy(),
+  };
+  const consoleSpy = sinon.spy(console, 'warn');
+  const nativeAPI = await helpers.createDanceAPI({
+    logger: loggerSpy
+  });
+
+  nativeAPI.setBackgroundEffect(invalidEffect);
+  t.equal(consoleSpy.callCount, 1);
+  t.equal(loggerSpy.logWarning.callCount, 1);
+  const warningMessage = loggerSpy.logWarning.firstCall.args[0];
+  t.true(warningMessage.includes(invalidEffect));
+
+  t.end();
+  nativeAPI.reset();
+  sinon.restore();
+});
+
+test('logs invalid foreground effect', async t => {
+  const invalidEffect = 'invalid';
+  const loggerSpy = {
+    logWarning: sinon.spy(),
+  };
+  const consoleSpy = sinon.spy(console, 'warn');
+  const nativeAPI = await helpers.createDanceAPI({
+    logger: loggerSpy
+  });
+
+  nativeAPI.setForegroundEffect(invalidEffect);
+  t.equal(consoleSpy.callCount, 1);
+  t.equal(loggerSpy.logWarning.callCount, 1);
+  const warningMessage = loggerSpy.logWarning.firstCall.args[0];
+  t.true(warningMessage.includes(invalidEffect));
+
+  t.end();
+  nativeAPI.reset();
+  sinon.restore();
+});
+
+test('logs invalid background palette', async t => {
+  const invalidPalette = 'invalid';
+  const loggerSpy = {
+    logWarning: sinon.spy(),
+  };
+  const consoleSpy = sinon.spy(console, 'warn');
+  const nativeAPI = await helpers.createDanceAPI({
+    logger: loggerSpy
+  });
+
+  nativeAPI.setBackgroundEffect('color_cycle', invalidPalette);
+  t.equal(consoleSpy.callCount, 1);
+  t.equal(loggerSpy.logWarning.callCount, 1);
+  const warningMessage = loggerSpy.logWarning.firstCall.args[0];
+  t.true(warningMessage.includes(invalidPalette));
+
+  t.end();
+  nativeAPI.reset();
+  sinon.restore();
 });

--- a/test/unit/effectsTest.js
+++ b/test/unit/effectsTest.js
@@ -140,7 +140,7 @@ test('random foreground effect', async t => {
 });
 
 test('logs invalid background effect', async t => {
-  const invalidEffect = 'invalid';
+  const invalidEffect = 'invalidBg';
   const loggerSpy = {
     logWarning: sinon.spy(),
   };
@@ -161,7 +161,7 @@ test('logs invalid background effect', async t => {
 });
 
 test('logs invalid foreground effect', async t => {
-  const invalidEffect = 'invalid';
+  const invalidEffect = 'invalidFg';
   const loggerSpy = {
     logWarning: sinon.spy(),
   };
@@ -182,7 +182,7 @@ test('logs invalid foreground effect', async t => {
 });
 
 test('logs invalid background palette', async t => {
-  const invalidPalette = 'invalid';
+  const invalidPalette = 'invalidPalette';
   const loggerSpy = {
     logWarning: sinon.spy(),
   };


### PR DESCRIPTION
Handle invalid background/foreground effects & palettes being set. This is pretty unlikely to happen, but if it does then we'd hit a crash trying to call `init()` on `undefined`. This could potentially occur, for example, if we accidentally change one of the AI outputs to an invalid value. This change will also log a warning to a supplied logger if it exists, which will look like:
<img width="461" alt="Screenshot 2023-11-16 at 3 30 51 PM" src="https://github.com/code-dot-org/dance-party/assets/85528507/d3f13711-dab6-40d4-91ee-3f9acb52215e">

Trello: https://trello.com/c/qUhwOQHI
Pairs with: https://github.com/code-dot-org/code-dot-org/pull/54999