### PR TITLE
Mirror generated dancer sprites

### DIFF
--- a/src/GeneratedDancer.js
+++ b/src/GeneratedDancer.js
@@ -40,6 +40,8 @@ class GeneratedDancer {
 
     this.graphics = this.p5.createGraphics(worldW, worldH);
     this.graphics.pixelDensity(1);
+    this.shouldMirror = 1;
+    this.mirror = 1;
 
     // Hand the renderer our mid-layer 2D context.
     this.renderer.init(this.graphics.drawingContext);
@@ -49,6 +51,19 @@ class GeneratedDancer {
     if (typeof src === 'number') {
       src = movesById[src] || movesById[0];
     }
+    const movesToMirror = new Set([
+      'rest',
+      'clap_high',
+      'dab',
+      'drop',
+      'floss',
+      'fresh',
+      'kick',
+      'roll',
+      'thriller',
+    ]);
+    this.shouldMirror = movesToMirror.has(src);
+
     return this.renderer.setSource(src);
   }
 
@@ -59,12 +74,12 @@ class GeneratedDancer {
     );
   }
 
-  render(frameIndex) {
+  render(frameIndex, mirror) {
     if (!this.graphics || !this.renderer) {
       return;
     }
     // The renderer paints directly into graphics.drawingContext
-    this.renderer.renderFrame(frameIndex);
+    this.renderer.renderFrame(frameIndex, mirror);
   }
 
   resize(worldW, worldH) {
@@ -93,6 +108,14 @@ class GeneratedDancer {
     this.graphics = null;
     this.renderer = null;
     this.p5 = null;
+  }
+
+  getMirror() {
+    return this.mirror;
+  }
+
+  setMirror(mirror) {
+    this.mirror = this.shouldMirror ? mirror : 1;
   }
 }
 

--- a/src/GeneratedDancer.js
+++ b/src/GeneratedDancer.js
@@ -40,7 +40,7 @@ class GeneratedDancer {
 
     this.graphics = this.p5.createGraphics(worldW, worldH);
     this.graphics.pixelDensity(1);
-    this.shouldMirror = 1;
+    this.shouldMirror = false;
     this.mirror = 1;
 
     // Hand the renderer our mid-layer 2D context.

--- a/src/GeneratedDancer.js
+++ b/src/GeneratedDancer.js
@@ -40,8 +40,7 @@ class GeneratedDancer {
 
     this.graphics = this.p5.createGraphics(worldW, worldH);
     this.graphics.pixelDensity(1);
-    this.shouldMirror = false;
-    this.mirror = 1;
+    this.danceMove = null;
 
     // Hand the renderer our mid-layer 2D context.
     this.renderer.init(this.graphics.drawingContext);
@@ -51,19 +50,7 @@ class GeneratedDancer {
     if (typeof src === 'number') {
       src = movesById[src] || movesById[0];
     }
-    const movesToMirror = new Set([
-      'rest',
-      'clap_high',
-      'dab',
-      'drop',
-      'floss',
-      'fresh',
-      'kick',
-      'roll',
-      'thriller',
-    ]);
-    this.shouldMirror = movesToMirror.has(src);
-
+    this.danceMove = src;
     return this.renderer.setSource(src);
   }
 
@@ -74,12 +61,12 @@ class GeneratedDancer {
     );
   }
 
-  render(frameIndex, mirror) {
+  render(frameIndex) {
     if (!this.graphics || !this.renderer) {
       return;
     }
     // The renderer paints directly into graphics.drawingContext
-    this.renderer.renderFrame(frameIndex, mirror);
+    this.renderer.renderFrame(frameIndex);
   }
 
   resize(worldW, worldH) {
@@ -110,12 +97,22 @@ class GeneratedDancer {
     this.p5 = null;
   }
 
-  getMirror() {
-    return this.mirror;
-  }
-
-  setMirror(mirror) {
-    this.mirror = this.shouldMirror ? mirror : 1;
+  shouldMirror(currentMeasure) {
+    const movesToMirror = new Set([
+      'rest',
+      'clap_high',
+      'dab',
+      'drop',
+      'floss',
+      'fresh',
+      'kick',
+      'roll',
+      'thriller',
+    ]);
+    return (
+      movesToMirror.has(this.danceMove) &&
+      Math.floor(currentMeasure * 2) % 2 === 1
+    );
   }
 }
 

--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -683,8 +683,12 @@ module.exports = class DanceParty {
           animationLength - 1,
           Math.floor(measureTick * animationLength)
         );
+        // If the current measure is odd, mirror the generated dancer.
+        const shouldMirror = Math.floor(currentMeasure * 2) % 2 === 1;
+        const mirror = shouldMirror ? -1 : 1;
+        this.generatedDancer.setMirror(mirror);
 
-        this.generatedDancer.render(measureFrame);
+        this.generatedDancer.render(measureFrame, mirror);
       }
     };
 
@@ -695,6 +699,7 @@ module.exports = class DanceParty {
 
     sprite.draw = () => {
       if (this.generatedDancer) {
+        sprite.mirrorX(this.generatedDancer.getMirror());
         this.p5_.image(
           this.generatedDancer.graphics,
           sprite.x - location.x,

--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -683,12 +683,7 @@ module.exports = class DanceParty {
           animationLength - 1,
           Math.floor(measureTick * animationLength)
         );
-        // If the current measure is odd, mirror the generated dancer.
-        const shouldMirror = Math.floor(currentMeasure * 2) % 2 === 1;
-        const mirror = shouldMirror ? -1 : 1;
-        this.generatedDancer.setMirror(mirror);
-
-        this.generatedDancer.render(measureFrame, mirror);
+        this.generatedDancer.render(measureFrame);
       }
     };
 
@@ -699,7 +694,9 @@ module.exports = class DanceParty {
 
     sprite.draw = () => {
       if (this.generatedDancer) {
-        sprite.mirrorX(this.generatedDancer.getMirror());
+        sprite.mirrorX(
+          this.generatedDancer.shouldMirror(this.getCurrentMeasure()) ? -1 : 1
+        );
         this.p5_.image(
           this.generatedDancer.graphics,
           sprite.x - location.x,
@@ -1659,7 +1656,7 @@ module.exports = class DanceParty {
     if (!this.generatedDancer) {
       return;
     }
-
+    this.danceMove = source;
     this.generatedDancer.setSource(source);
   }
 


### PR DESCRIPTION
Relates to:
- https://github.com/code-dot-org/code-dot-org/pull/69142

This adds a way for generated dancer sprites to effectively mirror dance moves when needed. The `GeneratedDancer` layer will now manage a `mirror` property that gets updated during the sprite's `updateSpriteFrame` loop. When the animation has finished, we flip the `mirror` value. p5 handles the rest. This is only needed for dance moves that require mirroring.

With this change, generated dancers will be able to follow static sprite-sheet dancers across a sequence of any moves:


Before:

https://github.com/user-attachments/assets/354a7ece-10e0-4b5e-aa51-ed0768d776dc


After:

https://github.com/user-attachments/assets/316636e9-bae1-4c41-b313-a9412925a33d

