### PR TITLE
Generated dancer: render quality

### DIFF
--- a/src/GeneratedDancer.js
+++ b/src/GeneratedDancer.js
@@ -42,9 +42,9 @@ class GeneratedDancer {
 
     // Create a canvas to render into.  With a pixel density of 2, this will be 600px in width and height.
     const pixelDensity = this.p5._pixelDensity;
-    const imageWidth = pixelDensity * worldW * constants.GENERATED_DANCER_SCALE;
+    const imageWidth = worldW * pixelDensity * constants.GENERATED_DANCER_SCALE;
     const imageHeight =
-      pixelDensity * worldH * constants.GENERATED_DANCER_SCALE;
+      worldH * pixelDensity * constants.GENERATED_DANCER_SCALE;
 
     this.graphics = this.p5.createGraphics(imageWidth, imageHeight);
     this.graphics.pixelDensity(1);

--- a/src/GeneratedDancer.js
+++ b/src/GeneratedDancer.js
@@ -1,5 +1,9 @@
+const constants = require('./constants');
+
+
 // Thin p5 adapter: owns a p5.Graphics mid-layer and gives its 2D context
 // to the external renderer. CommonJS to match the rest of dance-party.
+
 
 // Map of move IDs to move names. These values are used to fetch source animation JSON.
 const movesById = {
@@ -38,7 +42,12 @@ class GeneratedDancer {
     this.p5 = p5;
     this.renderer = renderer;
 
-    this.graphics = this.p5.createGraphics(worldW, worldH);
+    // Create a canvas to render into.  With a pixel density of 2, this will be 600px in width and height.
+    const pixelDensity = this.p5._pixelDensity;
+    const imageWidth = pixelDensity * worldW * constants.GENERATED_DANCER_SCALE;
+    const imageHeight = pixelDensity * worldH * constants.GENERATED_DANCER_SCALE;
+
+    this.graphics = this.p5.createGraphics(imageWidth, imageHeight);
     this.graphics.pixelDensity(1);
     this.danceMove = null;
 

--- a/src/GeneratedDancer.js
+++ b/src/GeneratedDancer.js
@@ -1,9 +1,7 @@
 const constants = require('./constants');
 
-
 // Thin p5 adapter: owns a p5.Graphics mid-layer and gives its 2D context
 // to the external renderer. CommonJS to match the rest of dance-party.
-
 
 // Map of move IDs to move names. These values are used to fetch source animation JSON.
 const movesById = {
@@ -45,7 +43,8 @@ class GeneratedDancer {
     // Create a canvas to render into.  With a pixel density of 2, this will be 600px in width and height.
     const pixelDensity = this.p5._pixelDensity;
     const imageWidth = pixelDensity * worldW * constants.GENERATED_DANCER_SCALE;
-    const imageHeight = pixelDensity * worldH * constants.GENERATED_DANCER_SCALE;
+    const imageHeight =
+      pixelDensity * worldH * constants.GENERATED_DANCER_SCALE;
 
     this.graphics = this.p5.createGraphics(imageWidth, imageHeight);
     this.graphics.pixelDensity(1);

--- a/src/constants.js
+++ b/src/constants.js
@@ -43,7 +43,8 @@ module.exports = {
     {name: 'XSlide', mirror: false, shortBurst: true},
   ],
   RANDOM_EFFECT_KEY: 'rand',
-  BACKGROUND_EFFECTS: [ // Effect name in Code.org Dance Party (if different than key listed here)
+  BACKGROUND_EFFECTS: [
+    // Effect name in Code.org Dance Party (if different than key listed here)
     'blooming_petals',
     'circles',
     'clouds',
@@ -71,9 +72,10 @@ module.exports = {
     'starburst',
     'stars',
     'swirl', // Hypno
-    'text' // Song Names
+    'text', // Song Names
   ],
-  FOREGROUND_EFFECTS: [ // Effect name in Code.org Dance Party (if different than key listed here)
+  FOREGROUND_EFFECTS: [
+    // Effect name in Code.org Dance Party (if different than key listed here)
     'bubbles',
     'color_lights', // Stage Lights
     'confetti',
@@ -90,7 +92,7 @@ module.exports = {
     'raining_tacos', // Tacos
     'smile_face', // Smiles
     'smiling_poop', // Poop
-    'spotlight'
+    'spotlight',
   ],
   PALETTES: {
     default: ['#ffa899', '#99aaff', '#99ffac', '#fcff99', '#ffdd99'],
@@ -104,7 +106,15 @@ module.exports = {
     rave: ['#000000', '#5b6770', '#c6cacd', '#e7e8ea', '#ffffff'],
     // Color palettes from poetry lab - a few of the color values have been changed
     // so that the sprite dancers are more visible or 'pop' against the background.
-    grayscale: ['#000000', '#333333', '#626C7D', '#999999', '#CCCCCC', '#EEEEEE', '#FFFFFF'],
+    grayscale: [
+      '#000000',
+      '#333333',
+      '#626C7D',
+      '#999999',
+      '#CCCCCC',
+      '#EEEEEE',
+      '#FFFFFF',
+    ],
     sky: ['#3878A4', '#82A9B1', '#ECCEC4', '#F8B8A8', '#E4929C', '#7D7095'],
     ocean: ['#82A9B1', '#3FABE3', '#2C7DBB', '#1D57A0', '#144188', '#061F4B'],
     sunrise: ['#F5DC72', '#FC9103', '#F48363', '#F15C4C', '#372031'],
@@ -147,4 +157,7 @@ module.exports = {
     BACKGROUND: 1,
     FOREGROUND: 0.8,
   },
+  // Scale factor: make the generated dancer appear the same size as other dance sprites.
+  // At 1.0 scale, the rendered frame takes up the entire canvas.
+  GENERATED_DANCER_SCALE: 0.75,
 };

--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -695,11 +695,7 @@ module.exports = class DanceParty {
         );
         this.p5_.push();
         this.p5_.scale(1 / this.p5_._pixelDensity);
-        this.p5_.image(
-          this.generatedDancer.graphics,
-          sprite.x - location.x,
-          sprite.y - location.y
-        );
+        this.p5_.image(this.generatedDancer.graphics, 0, 0);
         this.p5_.pop();
       }
     };

--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -693,7 +693,6 @@ module.exports = class DanceParty {
         sprite.mirrorX(
           this.generatedDancer.shouldMirror(this.getCurrentMeasure()) ? -1 : 1
         );
-
         this.p5_.image(
           this.generatedDancer.graphics,
           sprite.x - location.x,

--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -1203,6 +1203,9 @@ module.exports = class DanceParty {
 
     if (property === 'scale') {
       sprite.scale = val / 100;
+      if (sprite.isGenDancer) {
+        sprite.scale /= this.p5_._pixelDensity;
+      }
       this.adjustSpriteDepth_(sprite);
     } else if (property === 'width' || property === 'height') {
       sprite[property] = SIZE * (val / 100);
@@ -1408,7 +1411,7 @@ module.exports = class DanceParty {
 
   getAdjustedSpriteDepth(sprite) {
     const spriteScale = sprite.isGenDancer
-      ? 1 / this.p5_._pixelDensity
+      ? sprite.scale * this.p5_._pixelDensity
       : sprite.scale;
     // Bias scale heavily (especially since it largely hovers around 1.0) but use
     // Y coordinate as the first tie-breaker and X coordinate as the second.

--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -1278,7 +1278,11 @@ module.exports = class DanceParty {
   }
 
   changePropBy(sprite, property, val) {
-    this.setProp(sprite, property, this.getProp(sprite, property) + val);
+    const currentValue = this.getProp(sprite, property);
+    const currentValueAdjusted = sprite.isGenDancer
+      ? currentValue * this.p5_._pixelDensity
+      : currentValue;
+    this.setProp(sprite, property, currentValueAdjusted + val);
   }
 
   setTintEach(group, val) {

--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -646,7 +646,7 @@ module.exports = class DanceParty {
     var sprite = this.p5_.createSprite(location.x, location.y);
     sprite.isGenDancer = true;
 
-    sprite.scale = 1 / this.p5_._pixelDensity;
+    sprite.scale = 1;
     sprite.mirroring = 1;
     sprite.looping_move = 0;
     sprite.looping_frame = 0;
@@ -693,11 +693,14 @@ module.exports = class DanceParty {
         sprite.mirrorX(
           this.generatedDancer.shouldMirror(this.getCurrentMeasure()) ? -1 : 1
         );
+        this.p5_.push();
+        this.p5_.scale(1 / this.p5_._pixelDensity);
         this.p5_.image(
           this.generatedDancer.graphics,
           sprite.x - location.x,
           sprite.y - location.y
         );
+        this.p5_.pop();
       }
     };
 
@@ -1203,9 +1206,6 @@ module.exports = class DanceParty {
 
     if (property === 'scale') {
       sprite.scale = val / 100;
-      if (sprite.isGenDancer) {
-        sprite.scale /= this.p5_._pixelDensity;
-      }
       this.adjustSpriteDepth_(sprite);
     } else if (property === 'width' || property === 'height') {
       sprite[property] = SIZE * (val / 100);
@@ -1278,11 +1278,7 @@ module.exports = class DanceParty {
   }
 
   changePropBy(sprite, property, val) {
-    const currentValue = this.getProp(sprite, property);
-    const currentValueAdjusted = sprite.isGenDancer
-      ? currentValue * this.p5_._pixelDensity
-      : currentValue;
-    this.setProp(sprite, property, currentValueAdjusted + val);
+    this.setProp(sprite, property, this.getProp(sprite, property) + val);
   }
 
   setTintEach(group, val) {
@@ -1414,13 +1410,10 @@ module.exports = class DanceParty {
   }
 
   getAdjustedSpriteDepth(sprite) {
-    const spriteScale = sprite.isGenDancer
-      ? sprite.scale * this.p5_._pixelDensity
-      : sprite.scale;
     // Bias scale heavily (especially since it largely hovers around 1.0) but use
     // Y coordinate as the first tie-breaker and X coordinate as the second.
     // (Both X and Y range from 0-399 pixels.)
-    return 10000 * spriteScale + (100 * sprite.y) / 400 + (1 * sprite.x) / 400;
+    return 10000 * sprite.scale + (100 * sprite.y) / 400 + (1 * sprite.x) / 400;
   }
 
   // Behaviors

--- a/src/p5.dance.js
+++ b/src/p5.dance.js
@@ -33,10 +33,6 @@ const WATCHED_RANGES = [0, 1, 2];
 const SIZE = constants.SIZE;
 const FRAMES = constants.FRAMES;
 
-// Scale factor make the generated dancer appear the same size as other dance sprites.
-// At 1.0 scale, the rendered frame takes up the entire canvas.
-const GENERATED_DANCER_SCALE = 0.75;
-
 // NOTE: min and max are inclusive
 function randomInt(min, max) {
   return Math.floor(Math.random() * (max - min + 1)) + min;
@@ -650,7 +646,7 @@ module.exports = class DanceParty {
     var sprite = this.p5_.createSprite(location.x, location.y);
     sprite.isGenDancer = true;
 
-    sprite.scale = GENERATED_DANCER_SCALE;
+    sprite.scale = 1 / this.p5_._pixelDensity;
     sprite.mirroring = 1;
     sprite.looping_move = 0;
     sprite.looping_frame = 0;
@@ -697,6 +693,7 @@ module.exports = class DanceParty {
         sprite.mirrorX(
           this.generatedDancer.shouldMirror(this.getCurrentMeasure()) ? -1 : 1
         );
+
         this.p5_.image(
           this.generatedDancer.graphics,
           sprite.x - location.x,
@@ -1207,9 +1204,6 @@ module.exports = class DanceParty {
 
     if (property === 'scale') {
       sprite.scale = val / 100;
-      if (sprite.isGenDancer) {
-        sprite.scale *= GENERATED_DANCER_SCALE;
-      }
       this.adjustSpriteDepth_(sprite);
     } else if (property === 'width' || property === 'height') {
       sprite[property] = SIZE * (val / 100);
@@ -1415,7 +1409,7 @@ module.exports = class DanceParty {
 
   getAdjustedSpriteDepth(sprite) {
     const spriteScale = sprite.isGenDancer
-      ? sprite.scale / GENERATED_DANCER_SCALE
+      ? 1 / this.p5_._pixelDensity
       : sprite.scale;
     // Bias scale heavily (especially since it largely hovers around 1.0) but use
     // Y coordinate as the first tie-breaker and X coordinate as the second.


### PR DESCRIPTION
This improves the render quality of a generated dancer in dance party.

We've seen that the Lottie renderer does a nice job of rendering the generated dancer into a canvas, using the full resolution of the provided canvas to render nice anti-aliased shapes, as seen in the Generate Dancer levels of the Hour of AI 2025 progression.

Before now, the generated dancer in a dance party looked fairly pixelated, with noticeable aliasing artifacts.  On a retina display with a pixel density of 2, the dancer was first rendered into a 400x400 canvas.  This was then rendered into the final canvas, which is actually 800x800 pixels, at a 600x600 size.  

Now, we take advantage of the fact that the generated dancer is rendered in this progression at a consistent size to improve this pipeline a little.  We have Lottie render the dancer into a 600x600 canvas.  This is then rendered into the final 800x800 canvas, unchanged.

The result is a higher resolution dancer with somewhat fewer aliasing issues.

It's worth noting that the final 800x800 canvas is then scaled to the size of its element on the screen.  It would be interesting to always size this canvas to its onscreen size, but out of scope for now.

Thanks to @mikeharv for trying this out and sharing some more scenarios that this code could support if we introduce more blocks in the future.  As a result, it supports size (both "set to" and "change by") and position (initial, "set to", and "change by").

Tested with pixel density of 1, 2, and 3.

## Screenshots

Screenshots at pixel density of 2:

### Before

<img width="1485" height="1069" alt="Screenshot 2025-11-14 at 7 14 50 PM" src="https://github.com/user-attachments/assets/fa8ea1df-bfba-4473-87fc-0ebc1c6ae04a" />

### After

<img width="1485" height="1069" alt="Screenshot 2025-11-14 at 7 14 46 PM" src="https://github.com/user-attachments/assets/dfdd56cb-fb23-460c-bce8-db28372e280f" />
